### PR TITLE
Adds LUIS app configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Detailed information on the CLI tool sub-commands and arguments can be found in 
 - [Testing an NLU service](docs/Testing.md)
 - [Tearing down an NLU service](docs/Clean.md)
 - [Generic Utterances Model](docs/GenericUtterances.md)
+- [LUIS App Configuration](docs/LuisSettings.md)
 
 ## Contributing
 

--- a/docs/LuisSettings.md
+++ b/docs/LuisSettings.md
@@ -1,0 +1,179 @@
+# LUIS App Configuration
+
+The `train` and `test` sub-commands in the NLU.DevOps CLI tool both accept an `--extra-settings` parameter, which allows the user to configure entity types, as well as other NLU service specific features such as builtin intents and phrase lists.
+
+The `--extra-settings` for LUIS is a JSON object with two properties,  `appTemplate` and `prebuiltEntityTypes`. The former allows you to specify a partial LUIS import JSON with identical schema to the [LUIS import JSON schema](https://westus.dev.cognitive.microsoft.com/docs/services/5890b47c39e2bb17b84a55ff/operations/5890b47c39e2bb052c5b9c31). The latter refers to mappings from the from user supplied names for entity types to LUIS prebuilt entity type names.
+
+## Configuring LUIS entity types
+
+### Closed lists
+
+To configure an entity type as a closed list from LUIS, add the following to the `appTemplate` property of your LUIS settings JSON (i.e., the [`--extra-settings`](Training.md#-e---extra--settings) file supplied to the `train` command):
+```json
+{
+  "appTemplate": {
+    "closedLists": [
+      {
+        "name": "Genre",
+        "subLists": [
+          {
+            "canonicalForm": "country",
+            "list": []
+          },
+          {
+            "canonicalForm": "hip hop",
+            "list": []
+          },
+          {
+            "canonicalForm": "jazz",
+            "list": []
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Prebuilt domain entities
+
+To configure an entity type as a prebuilt domain entity from LUIS, add the following to the `appTemplate` property of your LUIS settings JSON (i.e., the [`--extra-settings`](Training.md#-e---extra--settings) file supplied to the `train` command):
+```json
+{
+  "appTemplate": {
+    "entities": [
+      {
+        "name": "Genre",
+        "inherits": {
+          "domain_name": "Music",
+          "model_name": "Genre"
+        }
+      }
+    ]
+  }
+}
+```
+
+### Entities with phrase lists
+
+An alternative to closed lists for specifying entity types is to create a "simple" entity (i.e., an item in the `entities` property of the LUIS app JSON), and configure a phrase list that captures an non-exhaustive list of valid matches. To achieve this, add the following to the `appTemplate` property of your LUIS settings JSON (i.e., the [`--extra-settings`](Training.md#-e---extra--settings) file supplied to the `train` command):
+```json
+{
+  "appTemplate": {
+    "entities": [
+      {
+        "name": "Genre"
+      }
+    ],
+    "model_features": [
+      {
+        "name": "genre",
+        "mode": false,
+        "words": "hip hop,jazz,pop,country",
+        "activated": true
+      }
+    ]
+  }
+}
+```
+
+### Configuring prebuilt entity types
+
+Prebuilt entity types in LUIS are handled in a slightly different way than other entity types. Specifically, users cannot supply a custom name for prebuilt entity types, and the `type` label for recognized prebuilt entities in LUIS is prefixed with `builtin.`. E.g., if you add the `personName` prebuilt entity to a LUIS app, labeled entities returned from the service will have type `builtin.personName`. The expectation of the [utterances model](GenericUtterances.md) is that users supply their own name for all entity types, including those that will be configured as prebuilt entity types on LUIS. To overcome the limitation on LUIS, we've added a settings property called `prebuiltEntityTypes`. This property includes all mappings from user supplied names for entity types to the LUIS prebuilt entity type name.
+
+E.g., for the following training utterances:
+```json
+[
+  {
+    "text": "say hi to bill",
+    "intent": "SendMessage",
+    "entities": [
+      {
+        "entityType": "Recipient",
+        "matchText": "bill",
+        "matchIndex": 0
+      }
+    ]
+  },
+  {
+    "text": "tell anne thanks",
+    "intent": "SendMessage",
+    "entities": [
+      {
+        "entityType": "Recipient",
+        "matchText": "anne",
+        "matchIndex": 0
+      }
+    ]
+  },
+  {
+    "text": "say goodbye to mary",
+    "intent": "SendMessage",
+    "entities": [
+      {
+        "entityType": "Recipient",
+        "matchText": "mary",
+        "matchIndex": 0
+      }
+    ]
+  }
+]
+```
+
+To configure the `Recipient` entity type as a LUIS prebuilt entity, the [`--extra-settings`](Training.md#-e---extra--settings) file supplied to the `train` command should look like:
+```json
+{
+  "builtinEntityTypes": {
+    "Recipient": "personName"
+  },
+  "appTemplate": {
+    "prebuiltEntities": [
+      {
+        "name": "personName"
+      }
+    ]
+  }
+}
+```
+
+During testing, to ensure that the entity types returned from LUIS are remapped back to the user-supplied entity type name, you must also supply the LUIS settings file above to the `test` command via the [`--extra-settings`](Testing.md#-e---extra--settings) option.
+
+## Configuring builtin intents
+
+To configure a builtin intent LUIS, add the following to the `appTemplate` property of your LUIS settings JSON (i.e., the [`--extra-settings`](Training.md#-e---extra--settings) file supplied to the `train` command):
+```json
+{
+  "appTemplate": {
+    "intents": [
+      {
+        "name": "Skip",
+        "inherits": {
+          "domain_name": "Music",
+          "model_name": "SkipForward"
+        }
+      }
+    ],
+    "utterances": [
+      {
+        "text": "next song",
+        "intent": "Skip",
+        "entities": []
+      }
+    ]
+  }
+}
+```
+
+Note that for LUIS, you will also need to include at least one utterance for each configured intent, including builtin intents. If you do not wish to include utterances in the generic utterances file supplied to the `train` command, it's fine to add these to the `appTemplate` section as well. We've done this in the sample above.
+
+## Schema
+
+### `prebuiltEntityTypes`
+(Optional) The mapping from user-supplied entity type names to LUIS prebuilt entity names.
+
+See [Configuring prebuilt entity types](#configuring-prebuilt-entity-types) for more information.
+
+### `appTemplate`
+(Optional) The partial LUIS import JSON that will be used 
+
+Note, if you plan to train and test with entities, you must supply entity type configurations through this property. See [Configuring LUIS entity types](#configuring-luis-entity-types) for more information.

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -151,5 +151,5 @@ See [Caching speech-to-text transcriptions](#caching-speech-to-text-transcriptio
 ### `-e, --extra-settings`
 (Optional) Path to NLU service-specific settings.
 
-This is currently only used for LUIS, see the section on prebuilt entity types in [Configuring LUIS Apps](TODO).
+This is currently only used for LUIS, see the section on prebuilt entity types in [Configuring prebuilt entity types](LuisSettings.md#configuring-prebuilt-entity-types).
 

--- a/docs/Training.md
+++ b/docs/Training.md
@@ -126,7 +126,7 @@ In this case, you must supply the `settings.luis.json` file that configures the 
 
 The `settings.luis.json` file in this case will be merged into the generated LUIS app JSON that will be imported into the version created by the train command, so the entity type for genre will use the builtin domain entity type, `Music.Genre`.
 
-See [LUIS App Configuration](TODO) and [Lex App Configuration](TODO) for additional information on the kinds of settings, including entity types, that are supplied through this file.
+See [LUIS App Configuration](LuisSettings.md) and [Lex App Configuration](TODO) for additional information on the kinds of settings, including entity types, that are supplied through this file.
 
 ### `-c, --overwrite-config`
 


### PR DESCRIPTION
The documentation includes the two top-level properties, `prebuiltEntityTypes` and `appTemplate`, as well as instructions for configuring various entity types and builtin intents.