### PR TITLE
Adds docs for LUIS appsettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,16 @@ This will install the CLI tool to your default .NET Core tools path. See the [do
 The service by default supports training and testing NLU models against [LUIS](https://www.luis.ai) and [Lex](https://aws.amazon.com/lex/).
 
 Detailed information on the CLI tool sub-commands and arguments can be found in the [docs](docs) folder:
-- [Training an NLU service](docs/Training.md)
-- [Testing an NLU service](docs/Testing.md)
+- [Training an NLU service](docs/Train.md)
+- [Testing an NLU service](docs/Test.md)
 - [Tearing down an NLU service](docs/Clean.md)
 - [Analyzing NLU service results](docs/Compare.md)
-- [Generic Utterances Model](docs/GenericUtterances.md)
-- [LUIS App Configuration](docs/LuisSettings.md)
-- [Lex App Configuration](docs/LexSettings.md)
+- [Generic utterances model](docs/GenericUtterances.md)
+- [LUIS app configuration](docs/LuisSettings.md)
+- [Lex bot configuration](docs/LexSettings.md)
+- [Configuring LUIS secrets](docs/LuisSecrets.md)
 
 ## Contributing
-
-See [docs](docs)
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us

--- a/docs/Clean.md
+++ b/docs/Clean.md
@@ -9,13 +9,13 @@ Run the following command:
 dotnet nlu clean -s luis
 ```
 
-To make things easier, be sure to use the `--overwrite-config` option in the `train` command to ensure an `appsettings.json` file is generated with the NLU service-specific details needed to make this call. Use the [`--delete-config`](#-c---delete-config) to delete the `appsettings.json` file after the resources are cleaned up.
+To make things easier, be sure to use the [`--save-appsettings`](Train.md#-a---save-appsettings) option in the `train` command to ensure an `appsettings.json` file is generated with the NLU service-specific details needed to make this call. Use the [`--delete-appsettings`](#-a---delete-appsettings) to delete the `appsettings.json` file after the resources are cleaned up.
 
 ## Detailed Usage
 
 ### `-s, --service`
 Identifier of the NLU service to run against. Try `luis` for [LUIS](https://www.luis.ai) or `lex` for [Lex](https://aws.amazon.com/lex/).
 
-### `-c, --delete-config`
+### `-a, --delete-appsettings`
 
-(Optional) Delete the NLU service-specific configuration overrides that were generated using the `--overwrite-config` option in a `train` command.
+(Optional) Delete the NLU service-specific configuration overrides that were generated using the `--save-appsettings` option in a `train` command.

--- a/docs/Compare.md
+++ b/docs/Compare.md
@@ -10,11 +10,11 @@ dotnet nlu compare -e utterances.json -a results.json
 ```
 
 The `utterances.json` argument is the path to the "expected" utterances file, usually the file path you supplied to the `test` command. The `results.json` is the path to the 
-to the output utterances from a `test` command (see [Testing an NLU service](Testing.md) for more details). The two files must have the same number of utterances in the exact same order, which will be the case if you supply the same `utterances.json` to the `compare` command as you supplied to `test`.
+to the output utterances from a `test` command (see [Testing an NLU service](Test.md) for more details). The two files must have the same number of utterances in the exact same order, which will be the case if you supply the same `utterances.json` to the `compare` command as you supplied to `test`.
 
 The `compare` sub-command will generate sensitivity and specifity test results for the text, intents, and entities in the two files. I.e., it will identify true positives, true negatives, false positives, and false negatives for text, intents, entities and entity values.
 
-For example, if you use the training cases supplied in [Training an NLU service](Training.md#getting-started) and the test cases supplied in [Testing an NLU Service](Testing.md#getting-started) on LUIS, you will recall that we had one resulting intent that was incorrectly labeled with the "None" intent. In this case, the `compare` command will generate passing tests (either true positive or true negative) for all text, intents, and entities, except for the one mismatched case. The mismatched case will generate a single failing test result, labeled as a false negative intent. Here is the specific output:
+For example, if you use the training cases supplied in [Training an NLU service](Train.md#getting-started) and the test cases supplied in [Testing an NLU Service](Test.md#getting-started) on LUIS, you will recall that we had one resulting intent that was incorrectly labeled with the "None" intent. In this case, the `compare` command will generate passing tests (either true positive or true negative) for all text, intents, and entities, except for the one mismatched case. The mismatched case will generate a single failing test result, labeled as a false negative intent. Here is the specific output:
 ```bash
 Test Discovery
   Start time: 2018-12-12 21:51:23Z
@@ -63,7 +63,7 @@ Usually, this is the same file you supplied to the `test` command.
 ### `-a, --actual`
 The path to the result utterances from the `test` command.
 
-Be sure to use the [`--output`](Testing.md#-o---output) option when running the `test` command.
+Be sure to use the [`--output`](Test.md#-o---output) option when running the `test` command.
 
 ### `-o, --output-folder`
 (Optional) The path to write the NUnit test results.

--- a/docs/GenericUtterances.md
+++ b/docs/GenericUtterances.md
@@ -1,4 +1,4 @@
-# Generic Utterances Model
+# Generic utterances model
 
 The NLU.DevOps CLI tool uses a generic utterances format that can work with multiple NLU services, and also contains enough information for sensitivity and specificity testing across intents and entities.
 

--- a/docs/LexSettings.md
+++ b/docs/LexSettings.md
@@ -1,14 +1,14 @@
-# Lex App Configuration
+# Lex bot configuration
 
-The `train` and `test` sub-commands in the NLU.DevOps CLI tool both accept an `--extra-settings` parameter, which allows the user to configure entity types, as well as other NLU service specific features such as builtin intents.
+The `train` and `test` sub-commands in the NLU.DevOps CLI tool both accept an `--service-settings` parameter, which allows the user to configure entity types, as well as other NLU service specific features such as builtin intents.
 
-The `--extra-settings` for Lex is a JSON object with two properties,  `importBotTemplate` and `slots`. The former allows you to specify a partial Lex import JSON with identical schema to the [Lex import JSON schema](https://docs.aws.amazon.com/lex/latest/dg/import-export-format.html). The latter refers entity type configurations for any slots that show up in training utterances.
+The `--service-settings` for Lex is a JSON object with two properties,  `importBotTemplate` and `slots`. The former allows you to specify a partial Lex import JSON with identical schema to the [Lex import JSON schema](https://docs.aws.amazon.com/lex/latest/dg/import-export-format.html). The latter refers entity type configurations for any slots that show up in training utterances.
 
 ## Configuring Lex slots
 
 ### Custom slots
 
-To configure an entity type with a custom slot on Lex, add the following to the `importBotTemplate` property of your Lex settings JSON (i.e., the [`--extra-settings`](Training.md#-e---extra-settings) file supplied to the `train` command):
+To configure an entity type with a custom slot on Lex, add the following to the `importBotTemplate` property of your Lex settings JSON (i.e., the [`--service-settings`](Train.md#-e---service-settings) file supplied to the `train` command):
 ```json
 {
   "slots": [
@@ -47,7 +47,7 @@ Note that in the case of `Genre`, we needed to remap the slot type to a name tha
 
 ### Built-in slots
 
-To configure an entity type as a built-in slot type from Lex, add the following to the `slots` property of your Lex settings JSON (i.e., the [`--extra-settings`](Training.md#-e---extra-settings) file supplied to the `train` command):
+To configure an entity type as a built-in slot type from Lex, add the following to the `slots` property of your Lex settings JSON (i.e., the [`--service-settings`](Train.md#-e---service-settings) file supplied to the `train` command):
 ```json
 {
   "slots": [
@@ -63,7 +63,7 @@ Any intents that include utterances with the `Genre` entity will include a slot 
 
 ## Configuring builtin intents
 
-To configure a built-in intent for Lex, add the following to the `importBotTemplate` property of your Lex settings JSON (i.e., the [`--extra-settings`](Training.md#-e---extra-settings) file supplied to the `train` command):
+To configure a built-in intent for Lex, add the following to the `importBotTemplate` property of your Lex settings JSON (i.e., the [`--service-settings`](Train.md#-e---service-settings) file supplied to the `train` command):
 ```json
 {
   "importBotTemplate": {

--- a/docs/LuisSecrets.md
+++ b/docs/LuisSecrets.md
@@ -1,0 +1,123 @@
+# Configuring LUIS secrets
+
+Before using the NLU.DevOps tool, you need to supply subscription keys to be able to train or test LUIS. To split up the keys settings that are "safe" for check-in to source control and those that should remain secure, the NLU.DevOps tool splits the settings into the [`--service-settings`](Train.md#-e---service-settings) command line option, which points to a file that can be checked in to source control, and settings configured through [`Microsoft.Extensions.Configuration`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.configuration?view=aspnetcore-2.1) (i.e., an `appsettings.json` file or environment variables). This document focuses on the latter.
+
+## Configuring secrets for training
+
+At a minimum to get started, you must supply the LUIS authoring key and authoring region to train a model with the NLU.DevOps CLI tools.
+```json
+{
+  "luisAuthoringKey": "...",
+  "luisAuthoringRegion": "westus"
+}
+```
+
+This will allow you to call the `train` sub-command for LUIS (see [Training an NLU Service](Train.md) for more details).
+
+Options to consider for training a LUIS model include:
+- [`luisAuthoringKey`](#luisauthoringkey)
+- [`luisAuthoringRegion`](#luisauthoringregion)
+- [`luisAppId`](#luisappid)
+- [`luisIsStaging`](#luisisstaging)
+- [`luisAppName`](#luisappname)
+- [`luisAppNamePrefix`](#luisappnameprefix)
+- [`luisVersionId`](#luisversionid)
+- [`BUILD_BUILDID`](#build_buildid)
+
+## Configuring secrets for testing
+
+At a minimum to get started, you must supply a LUIS authoring or endpoint key, an authoring or endpoint region, and an app ID to test a model with the NLU.DevOps CLI tools.
+```json
+{
+  "luisAuthoringKey": "...",
+  "luisAuthoringRegion": "westus",
+  "luisAppId": "00000000-0000-0000-0000-000000000000"
+}
+```
+
+This will allow you to call the `test` sub-command for LUIS (see [Testing an NLU Service](Test.md) for more details).
+
+Please note, to simplify the configuration process in continuous integration scenarios, you can use the [`--save-appsettings`](Train.md#-a---save-appsettings) to save the LUIS app ID generated from a previous call to `train` in a `appsettings.luis.json` file.
+
+Also note that the LUIS authoring key has a [quota](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-boundaries#key-limits) when used for query (up to 1,000 text queries/month and at most 5 requests/second). As such it is recommended that you suppy a [`luisEndpointKey`](#luisendpointkey) and [`luisEndpointRegion`](#luisendpointregion). You may not use the [`luisAuthoringKey`](#luisauthoringkey) for testing with the [`--speech`](Test.md#--speech) option, unless you also supply a [`speechKey`](#speechkey). 
+
+Other options to consider for testing a LUIS model include:
+- [`luisAuthoringKey`](#luisauthoringkey)
+- [`luisAuthoringRegion`](#luisauthoringregion)
+- [`luisEndpointKey`](#luisendpointkey)
+- [`luisEndpointRegion`](#luisendpointregion)
+- [`speechKey`](#speechkey)
+- [`luisAppId`](#luisappid)
+
+## Configuring secrets for clean
+
+At a minimum to get started, you must supply a LUIS authoring key, an authoring region, and an app ID to delete a LUIS model with the NLU.DevOps CLI tools.
+```json
+{
+  "luisAuthoringKey": "...",
+  "luisAuthoringRegion": "westus",
+  "luisAppId": "00000000-0000-0000-0000-000000000000"
+}
+```
+
+This will allow you to call the `clean` sub-command for LUIS (see [Tearing down an NLU Service](Clean.md) for more details).
+
+Options to consider for tearing down a LUIS model include:
+- [`luisAuthoringKey`](#luisauthoringkey)
+- [`luisAuthoringRegion`](#luisauthoringregion)
+- [`luisAppId`](#luisappid)
+
+## App Settings Variables
+
+### `luisAuthoringKey`
+(Optional) The LUIS authoring key.
+
+Required for `train` and `clean`. May be used (to a limited extent subject to [quota](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-boundaries#key-limits)) for `test` from text.
+
+### `luisAuthoringRegion`
+(Optional) The LUIS authoring region.
+
+Required for `train` and `clean`. May be used (to a limited extent subject to [quota](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-boundaries#key-limits)) for `test` from text.
+
+### `luisEndpointKey`
+(Optional) The LUIS endpoint key.
+
+### `luisEndpointRegion`
+(Optional) The LUIS endpoint region.
+
+### `speechKey`
+(Optional) The LUIS speech key.
+
+When supplied, the `speechKey` will configure LUIS to make a REST call to transcribe the speech prior to sending the transcribed text to LUIS, rather than making an end-to-end call using the [Speech Service SDK](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-sdk).
+
+### `luisAppId`
+(Optional) The LUIS app ID.
+
+Required for `test` and `clean`. Optional for `train`; when supplied, the sub-command will publish a new version to the existing LUIS app, rather than creating a new LUIS app.
+
+### `luisIsStaging`
+(Optional) Boolean signaling whether to use the LUIS staging endpoint.
+
+Optional for `train` and `test`. When supplied for `train` as `true`, the CLI tool will publish the model to the staging endpoint. When supplied for `test` as `true`, the CLI tool will make requests against the staging endpoint.
+
+### `luisAppNamePrefix`
+(Optional) The prefix for the app name to supply when creating and importing a new LUIS app.
+
+This option is only used when `luisAppName` is not provided. The prefix will be prepended to a random eight character string to generate the app name. A common use case for the `luisAppNamePrefix` is in continuous integration scenarios, when a generated name is needed, but you may also want to have a prefix to filter on.
+
+### `luisAppName`
+(Optional) The app name to supply when creating and importing a new LUIS app.
+
+If not supplied, a random eight character string will be generated for the app name, potentially with the [`luisAppNamePrefix`](#luisappnameprefix).
+
+### `luisVersionId`
+(Optional) The version ID to use when importing a LUIS model.
+
+If not supplied, the default version ID is `0.1.1`, for compatibility with the default version ID used when creating a LUIS app (`0.1`). If supplied, the [`BUILD_BUILDID`](#build_buildid) will be appended to the version ID.
+
+### `BUILD_BUILDID`
+(Optional) Suffix for LUIS version ID.
+
+When supplied the `BUILD_BUILDID` value will be appended to the [`luisVersionId`](#luisversionid) (or `0.1.1` if it's not provided). This is useful in continuous integration and deployment scenarios when you need to generate a new version ID to import a new LUIS model. 
+
+Note that the `BUILD_BUILDID` environment variable is available by default in [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) builds.

--- a/docs/LuisSettings.md
+++ b/docs/LuisSettings.md
@@ -1,14 +1,14 @@
-# LUIS App Configuration
+# LUIS app configuration
 
-The `train` and `test` sub-commands in the NLU.DevOps CLI tool both accept an `--extra-settings` parameter, which allows the user to configure entity types, as well as other NLU service specific features such as builtin intents and phrase lists.
+The `train` and `test` sub-commands in the NLU.DevOps CLI tool both accept an `--service-settings` parameter, which allows the user to configure entity types, as well as other NLU service specific features such as builtin intents and phrase lists.
 
-The `--extra-settings` for LUIS is a JSON object with two properties,  `appTemplate` and `prebuiltEntityTypes`. The former allows you to specify a partial LUIS import JSON with identical schema to the [LUIS import JSON schema](https://westus.dev.cognitive.microsoft.com/docs/services/5890b47c39e2bb17b84a55ff/operations/5890b47c39e2bb052c5b9c31). The latter refers to mappings from the from user supplied names for entity types to LUIS prebuilt entity type names.
+The `--service-settings` for LUIS is a JSON object with two properties,  `appTemplate` and `prebuiltEntityTypes`. The former allows you to specify a partial LUIS import JSON with identical schema to the [LUIS import JSON schema](https://westus.dev.cognitive.microsoft.com/docs/services/5890b47c39e2bb17b84a55ff/operations/5890b47c39e2bb052c5b9c31). The latter refers to mappings from the from user supplied names for entity types to LUIS prebuilt entity type names.
 
 ## Configuring LUIS entities
 
 ### Closed lists
 
-To configure an entity type as a closed list from LUIS, add the following to the `appTemplate` property of your LUIS settings JSON (i.e., the [`--extra-settings`](Training.md#-e---extra-settings) file supplied to the `train` command):
+To configure an entity type as a closed list from LUIS, add the following to the `appTemplate` property of your LUIS settings JSON (i.e., the [`--service-settings`](Train.md#-e---service-settings) file supplied to the `train` command):
 ```json
 {
   "appTemplate": {
@@ -37,7 +37,7 @@ To configure an entity type as a closed list from LUIS, add the following to the
 
 ### Prebuilt domain entities
 
-To configure an entity type as a prebuilt domain entity from LUIS, add the following to the `appTemplate` property of your LUIS settings JSON (i.e., the [`--extra-settings`](Training.md#-e---extra-settings) file supplied to the `train` command):
+To configure an entity type as a prebuilt domain entity from LUIS, add the following to the `appTemplate` property of your LUIS settings JSON (i.e., the [`--service-settings`](Train.md#-e---service-settings) file supplied to the `train` command):
 ```json
 {
   "appTemplate": {
@@ -56,7 +56,7 @@ To configure an entity type as a prebuilt domain entity from LUIS, add the follo
 
 ### Entities with phrase lists
 
-An alternative to closed lists for specifying entity types is to create a "simple" entity (i.e., an item in the `entities` property of the LUIS app JSON), and configure a phrase list that captures an non-exhaustive list of valid matches. To achieve this, add the following to the `appTemplate` property of your LUIS settings JSON (i.e., the [`--extra-settings`](Training.md#-e---extra-settings) file supplied to the `train` command):
+An alternative to closed lists for specifying entity types is to create a "simple" entity (i.e., an item in the `entities` property of the LUIS app JSON), and configure a phrase list that captures an non-exhaustive list of valid matches. To achieve this, add the following to the `appTemplate` property of your LUIS settings JSON (i.e., the [`--service-settings`](Train.md#-e---service-settings) file supplied to the `train` command):
 ```json
 {
   "appTemplate": {
@@ -120,7 +120,7 @@ E.g., for the following training utterances:
 ]
 ```
 
-To configure the `Recipient` entity type as a LUIS prebuilt entity, the [`--extra-settings`](Training.md#-e---extra-settings) file supplied to the `train` command should look like:
+To configure the `Recipient` entity type as a LUIS prebuilt entity, the [`--service-settings`](Train.md#-e---service-settings) file supplied to the `train` command should look like:
 ```json
 {
   "builtinEntityTypes": {
@@ -136,11 +136,11 @@ To configure the `Recipient` entity type as a LUIS prebuilt entity, the [`--extr
 }
 ```
 
-During testing, to ensure that the entity types returned from LUIS are remapped back to the user-supplied entity type name, you must also supply the LUIS settings file above to the `test` command via the [`--extra-settings`](Testing.md#-e---extra-settings) option.
+During testing, to ensure that the entity types returned from LUIS are remapped back to the user-supplied entity type name, you must also supply the LUIS settings file above to the `test` command via the [`--service-settings`](Test.md#-e---service-settings) option.
 
 ## Configuring builtin intents
 
-To configure a builtin intent for LUIS, add the following to the `appTemplate` property of your LUIS settings JSON (i.e., the [`--extra-settings`](Training.md#-e---extra-settings) file supplied to the `train` command):
+To configure a builtin intent for LUIS, add the following to the `appTemplate` property of your LUIS settings JSON (i.e., the [`--service-settings`](Train.md#-e---service-settings) file supplied to the `train` command):
 ```json
 {
   "appTemplate": {

--- a/docs/Test.md
+++ b/docs/Test.md
@@ -39,7 +39,7 @@ The `utterances.json` argument is the path to the generic utterances file, which
 ]
 ```
 
-The resulting output will be a JSON array in the generic utterances format, with the intents and entities labeled by the NLU service. E.g., after training a LUIS service from [Getting Started section in Training NLU Services](Training.md#getting-started), testing with the example utterances above will output the following results:
+The resulting output will be a JSON array in the generic utterances format, with the intents and entities labeled by the NLU service. E.g., after training a LUIS service from [Getting Started section in Training NLU Services](Train.md#getting-started), testing with the example utterances above will output the following results:
 
 ```json
 [
@@ -98,7 +98,7 @@ dotnet nlu test -s luis --speech -u utterances.json
 
 You do not need to train your NLU service with the NLU.DevOps CLI tool in order to test it with the tool. You can just as easily point the tool at existing trained models, e.g., on LUIS or Lex without training from the CLI tool.
 
-See [LUIS Key Configuration](TODO) and [Lex Key Configuration](TODO) for more information on how to point to an existing service, e.g., with a LUIS app ID.
+See [LUIS Key Configuration](LuisSecrets.md) and [Lex Key Configuration](TODO) for more information on how to point to an existing service, e.g., with a LUIS app ID.
 
 ## Caching speech-to-text transcriptions
 
@@ -148,7 +148,7 @@ See [Getting started with speech](#getting-started-with-speech).
 
 See [Caching speech-to-text transcriptions](#caching-speech-to-text-transcriptions).
 
-### `-e, --extra-settings`
+### `-e, --service-settings`
 (Optional) Path to NLU service-specific settings.
 
 This is currently only used for LUIS, see the section on LUIS prebuilt entities in [Configuring prebuilt entities](LuisSettings.md#configuring-prebuilt-entities).

--- a/docs/Train.md
+++ b/docs/Train.md
@@ -41,7 +41,7 @@ The `utterances.json` argument is the path to the generic utterances file, which
 
 See [Generic Utterances Model](GenericUtterances.md) for more information on the JSON schema for utterances.
 
-See [LUIS Key Configuration](TODO) and [Lex Key Configuration](TODO) for more information on how to supply secrets, e.g., the authoring key, to the CLI tool.
+See [LUIS Key Configuration](LuisSecrets.md) and [Lex Key Configuration](TODO) for more information on how to supply secrets, e.g., the authoring key, to the CLI tool.
 
 ## Detailed Usage
 
@@ -51,7 +51,7 @@ Identifier of the NLU service to run against. Try `luis` for [LUIS](https://www.
 ### `-u, --utterances`
 (Optional) Path to labeled utterances to include in the model.
 
-### `-e, --extra-settings`
+### `-e, --service-settings`
 (Optional) Path to NLU service-specific settings.
 
 E.g., run the following command:
@@ -128,17 +128,17 @@ The `settings.luis.json` file in this case will be merged into the generated LUI
 
 See [LUIS App Configuration](LuisSettings.md) and [Lex App Configuration](LexSettings.md) for additional information on the kinds of settings, including entity types, that are supplied through this file.
 
-### `-c, --overwrite-config`
+### `-a, --save-appsettings`
 
-(Optional) Output additional app settings for resources that were created by the train command for use in subsequent commands.
+(Optional) Output additional appsettings for resources that were created by the train command for use in subsequent commands.
 
-The `--overwrite-config` option is useful when you will be running test commands after training. For example, running:
+The `--save-appsettings` option is useful when you will be running test commands after training. For example, running:
 ```bash
-dotnet nlu train -s luis -u utterances.json -c
+dotnet nlu train -s luis -u utterances.json -a
 dotnet nlu test -s luis -u tests.json
 ```
 
-The train command may create a new LUIS application, and the subsequent call to `dotnet nlu test` will need to know the LUIS app ID that was created in the first call. Using the `-c` option with LUIS, for example, will output a file in the current working directory called `appsettings.luis.json`, with the following settings:
+The train command may create a new LUIS application, and the subsequent call to `dotnet nlu test` will need to know the LUIS app ID that was created in the first call. Using the `-a` option with LUIS, for example, will output a file in the current working directory called `appsettings.luis.json`, with the following settings:
 ```json
 {
   "luisAppId": "<guid>",
@@ -146,4 +146,4 @@ The train command may create a new LUIS application, and the subsequent call to 
 }
 ```
 
-See [Testing NLU Services](Testing.md) for more information about the test command.
+See [Testing NLU Services](Test.md) for more information about the test command.


### PR DESCRIPTION
Includes information on the required and optional appsettings needed for `train`, `test` and `clean`.