### PR TITLE
Adds Lex appsettings configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Detailed information on the CLI tool sub-commands and arguments can be found in 
 - [Analyzing NLU service results](docs/Compare.md)
 - [Generic utterances model](docs/GenericUtterances.md)
 - [LUIS app configuration](docs/LuisSettings.md)
-- [Lex bot configuration](docs/LexSettings.md)
 - [Configuring LUIS secrets](docs/LuisSecrets.md)
+- [Lex bot configuration](docs/LexSettings.md)
+- [Configuring Lex secrets](docs/LexSecrets.md)
 
 ## Contributing
 

--- a/docs/LexSecrets.md
+++ b/docs/LexSecrets.md
@@ -1,0 +1,104 @@
+# Configuring Lex secrets
+
+Before using the NLU.DevOps tool, you need to supply AWS secrets to be able to train or test Lex. To split up the keys settings that are "safe" for check-in to source control and those that should remain secure, the NLU.DevOps tool splits the settings into the [`--service-settings`](Train.md#-e---service-settings) command line option, which points to a file that can be checked in to source control, and settings configured through [`Microsoft.Extensions.Configuration`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.configuration?view=aspnetcore-2.1) (i.e., an `appsettings.json` file or environment variables). This document focuses on the latter. See [Lex bot configuration](LexSettings.md) for details about the former.
+
+## Configuring secrets for training
+
+At a minimum to get started, you must supply the AWS access key and secret key with [relevant permissions](https://docs.aws.amazon.com/lex/latest/dg/access-control-managing-permissions.html) for Lex authoring, as well as the AWS region to train a model with the NLU.DevOps CLI tools.
+```json
+{
+  "awsAccessKey": "...",
+  "awsSecretKey": "...",
+  "awsRegion": "us-east-1"
+}
+```
+
+This will allow you to call the `train` sub-command for Lex (see [Training an NLU Service](Train.md) for more details).
+
+Options to consider for training a Lex bot include:
+- [`awsAccessKey`](#awsaccesskey)
+- [`awsSecretKey`](#awssecretkey)
+- [`awsRegion`](#awsregion)
+- [`lexBotName`](#lexbotname)
+- [`lexBotAlias`](#lexbotalias)
+- [`lexBotNamePrefix`](#lexbotnameprefix)
+
+## Configuring secrets for testing
+
+At a minimum to get started, you must supply the AWS access key and secret key with [relevant permissions](https://docs.aws.amazon.com/lex/latest/dg/access-control-managing-permissions.html) for Lex queries, as well as the AWS region, Lex bot name, and Lex bot alias to test a model with the NLU.DevOps CLI tools.
+```json
+{
+  "awsAccessKey": "...",
+  "awsSecretKey": "...",
+  "awsRegion": "us-east-1",
+  "lexBotName": "...",
+  "lexBotAlias": "..."
+}
+```
+
+This will allow you to call the `test` sub-command for Lex (see [Testing an NLU Service](Test.md) for more details).
+
+To simplify the configuration process in continuous integration scenarios, you can use the [`--save-appsettings`](Train.md#-a---save-appsettings) option to save the Lex bot name and bot alias used to `train` in a `appsettings.lex.json` file.
+
+Options to consider for testing a Lex bot include:
+- [`awsAccessKey`](#awsaccesskey)
+- [`awsSecretKey`](#awssecretkey)
+- [`awsRegion`](#awsregion)
+- [`lexBotName`](#lexbotname)
+- [`lexBotAlias`](#lexbotalias)
+
+## Configuring secrets for clean
+
+At a minimum to get started, you must supply the AWS access key and secret key with [relevant permissions](https://docs.aws.amazon.com/lex/latest/dg/access-control-managing-permissions.html) for Lex authoring, as well as the AWS region, Lex bot name, and Lex bot alias to delete a Lex bot with the NLU.DevOps CLI tools.
+```json
+{
+  "awsAccessKey": "...",
+  "awsSecretKey": "...",
+  "awsRegion": "us-east-1",
+  "lexBotName": "...",
+  "lexBotAlias": "..."
+}
+```
+
+This will allow you to call the `clean` sub-command for Lex (see [Tearing down an NLU Service](Clean.md) for more details).
+
+To simplify the configuration process in continuous integration scenarios, you can use the [`--save-appsettings`](Train.md#-a---save-appsettings) option to save the Lex bot name and bot alias used to `train` in a `appsettings.lex.json` file.
+
+Options to consider for tearing down a Lex bot include:
+- [`awsAccessKey`](#awsaccesskey)
+- [`awsSecretKey`](#awssecretkey)
+- [`awsRegion`](#awsregion)
+- [`lexBotName`](#lexbotname)
+- [`lexBotAlias`](#lexbotalias)
+
+## App Settings Variables
+
+### `awsAccessKey`
+AWS access key.
+
+Required for `train`, `test`, and `clean`. See [Managing Access Keys for IAM Users](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for more details.
+
+### `awsSecretKey`
+AWS secret key.
+
+Required for `train`, `test`, and `clean`. See [Managing Access Keys for IAM Users](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for more details.
+
+### `awsRegion`
+AWS region.
+
+Required for `train`, `test`, and `clean`. See [Managing Access Keys for IAM Users](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for more details.
+
+### `lexBotNamePrefix`
+(Optional) The prefix for the bot name and bot alias to supply when creating and importing a new Lex bot.
+
+Optional for `train`. This option is only used when [`lexBotName`](#lexbotname) is not provided. The prefix will be prepended to a random eight character string to generate the bot name. A common use case for the `lexBotNamePrefix` is in continuous integration scenarios, when a generated name is needed, but you may also want to have a prefix to filter on.
+
+### `lexBotName`
+(Optional) Lex bot name to use when training and testing a Lex bot. 
+
+Required for `test` and `clean`. Optional for `train`. If not supplied for `train`, a random eight character string will be generated for the Lex bot name, potentially with the [`lexBotNamePrefix`](#lexbotnameprefix).
+
+### `lexBotAlias`
+(Optional) Lex bot alias to use when training and testing a Lex bot.
+
+Required for `test` and `clean`. Optional for `train`. If not supplied for `train`, the [`lexBotName`](#lexbotname) will be used.

--- a/docs/LuisSecrets.md
+++ b/docs/LuisSecrets.md
@@ -1,10 +1,10 @@
 # Configuring LUIS secrets
 
-Before using the NLU.DevOps tool, you need to supply subscription keys to be able to train or test LUIS. To split up the keys settings that are "safe" for check-in to source control and those that should remain secure, the NLU.DevOps tool splits the settings into the [`--service-settings`](Train.md#-e---service-settings) command line option, which points to a file that can be checked in to source control, and settings configured through [`Microsoft.Extensions.Configuration`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.configuration?view=aspnetcore-2.1) (i.e., an `appsettings.json` file or environment variables). This document focuses on the latter.
+Before using the NLU.DevOps tool, you need to supply subscription keys to be able to train or test LUIS. To split up the keys settings that are "safe" for check-in to source control and those that should remain secure, the NLU.DevOps tool splits the settings into the [`--service-settings`](Train.md#-e---service-settings) command line option, which points to a file that can be checked in to source control, and settings configured through [`Microsoft.Extensions.Configuration`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.configuration?view=aspnetcore-2.1) (i.e., an `appsettings.json` file or environment variables). This document focuses on the latter. See [LUIS app configuration](LuisSettings.md) for details about the former.
 
 ## Configuring secrets for training
 
-At a minimum to get started, you must supply the LUIS authoring key and authoring region to train a model with the NLU.DevOps CLI tools.
+At a minimum to get started, you must supply the [LUIS authoring key](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-concept-keys) and authoring region to train a model with the NLU.DevOps CLI tools.
 ```json
 {
   "luisAuthoringKey": "...",
@@ -26,7 +26,7 @@ Options to consider for training a LUIS model include:
 
 ## Configuring secrets for testing
 
-At a minimum to get started, you must supply a LUIS authoring or endpoint key, an authoring or endpoint region, and an app ID to test a model with the NLU.DevOps CLI tools.
+At a minimum to get started, you must supply a [LUIS authoring or endpoint key](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-concept-keys), an authoring or endpoint region, and an app ID to test a model with the NLU.DevOps CLI tools.
 ```json
 {
   "luisAuthoringKey": "...",
@@ -37,11 +37,11 @@ At a minimum to get started, you must supply a LUIS authoring or endpoint key, a
 
 This will allow you to call the `test` sub-command for LUIS (see [Testing an NLU Service](Test.md) for more details).
 
-Please note, to simplify the configuration process in continuous integration scenarios, you can use the [`--save-appsettings`](Train.md#-a---save-appsettings) to save the LUIS app ID generated from a previous call to `train` in a `appsettings.luis.json` file.
+To simplify the configuration process in continuous integration scenarios, you can use the [`--save-appsettings`](Train.md#-a---save-appsettings) option to save the LUIS app ID generated from a previous call to `train` in a `appsettings.luis.json` file.
 
 Also note that the LUIS authoring key has a [quota](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-boundaries#key-limits) when used for query (up to 1,000 text queries/month and at most 5 requests/second). As such it is recommended that you suppy a [`luisEndpointKey`](#luisendpointkey) and [`luisEndpointRegion`](#luisendpointregion). You may not use the [`luisAuthoringKey`](#luisauthoringkey) for testing with the [`--speech`](Test.md#--speech) option, unless you also supply a [`speechKey`](#speechkey). 
 
-Other options to consider for testing a LUIS model include:
+Options to consider for testing a LUIS model include:
 - [`luisAuthoringKey`](#luisauthoringkey)
 - [`luisAuthoringRegion`](#luisauthoringregion)
 - [`luisEndpointKey`](#luisendpointkey)
@@ -62,6 +62,8 @@ At a minimum to get started, you must supply a LUIS authoring key, an authoring 
 
 This will allow you to call the `clean` sub-command for LUIS (see [Tearing down an NLU Service](Clean.md) for more details).
 
+To simplify the configuration process in continuous integration scenarios, you can use the [`--save-appsettings`](Train.md#-a---save-appsettings) option to save the LUIS app ID generated from a previous call to `train` in a `appsettings.luis.json` file.
+
 Options to consider for tearing down a LUIS model include:
 - [`luisAuthoringKey`](#luisauthoringkey)
 - [`luisAuthoringRegion`](#luisauthoringregion)
@@ -70,25 +72,29 @@ Options to consider for tearing down a LUIS model include:
 ## App Settings Variables
 
 ### `luisAuthoringKey`
-(Optional) The LUIS authoring key.
+(Optional) LUIS authoring key.
 
 Required for `train` and `clean`. May be used (to a limited extent subject to [quota](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-boundaries#key-limits)) for `test` from text.
 
 ### `luisAuthoringRegion`
-(Optional) The LUIS authoring region.
+(Optional) LUIS authoring region.
 
 Required for `train` and `clean`. May be used (to a limited extent subject to [quota](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-boundaries#key-limits)) for `test` from text.
 
 ### `luisEndpointKey`
-(Optional) The LUIS endpoint key.
+(Optional) LUIS endpoint key.
+
+Required for `test` when the [`--speech`](Test.md#--speech) option is used and the [`speechKey`](#speechkey) is not provided.
 
 ### `luisEndpointRegion`
-(Optional) The LUIS endpoint region.
+(Optional) LUIS endpoint region.
+
+Required for `test` when the [`--speech`](Test.md#--speech) option is used and the [`speechKey`](#speechkey) is not provided.
 
 ### `speechKey`
-(Optional) The LUIS speech key.
+(Optional) LUIS speech key.
 
-When supplied, the `speechKey` will configure LUIS to make a REST call to transcribe the speech prior to sending the transcribed text to LUIS, rather than making an end-to-end call using the [Speech Service SDK](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-sdk).
+Optional for `test`. When supplied, the `speechKey` will configure LUIS to make a REST call to transcribe the speech prior to sending the transcribed text to LUIS, rather than making an end-to-end call using the [Speech Service SDK](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-sdk).
 
 ### `luisAppId`
 (Optional) The LUIS app ID.
@@ -101,23 +107,21 @@ Required for `test` and `clean`. Optional for `train`; when supplied, the sub-co
 Optional for `train` and `test`. When supplied for `train` as `true`, the CLI tool will publish the model to the staging endpoint. When supplied for `test` as `true`, the CLI tool will make requests against the staging endpoint.
 
 ### `luisAppNamePrefix`
-(Optional) The prefix for the app name to supply when creating and importing a new LUIS app.
+(Optional) Prefix for the app name to supply when creating and importing a new LUIS app.
 
-This option is only used when `luisAppName` is not provided. The prefix will be prepended to a random eight character string to generate the app name. A common use case for the `luisAppNamePrefix` is in continuous integration scenarios, when a generated name is needed, but you may also want to have a prefix to filter on.
+Optional for `train`. This option is only used when [`luisAppName`](#luisappname) is not provided. The prefix will be prepended to a random eight character string to generate the app name. A common use case for the `luisAppNamePrefix` is in continuous integration scenarios, when a generated name is needed, but you may also want to have a prefix to filter on.
 
 ### `luisAppName`
-(Optional) The app name to supply when creating and importing a new LUIS app.
+(Optional) App name to supply when creating and importing a new LUIS app.
 
-If not supplied, a random eight character string will be generated for the app name, potentially with the [`luisAppNamePrefix`](#luisappnameprefix).
+Optional for `train`. If not supplied, a random eight character string will be generated for the app name, potentially with the [`luisAppNamePrefix`](#luisappnameprefix).
 
 ### `luisVersionId`
-(Optional) The version ID to use when importing a LUIS model.
+(Optional) Version ID to use when importing a LUIS model.
 
-If not supplied, the default version ID is `0.1.1`, for compatibility with the default version ID used when creating a LUIS app (`0.1`). If supplied, the [`BUILD_BUILDID`](#build_buildid) will be appended to the version ID.
+Optional for `train`. If not supplied, the default version ID is `0.1.1`, for compatibility with the default version ID used when creating a LUIS app (`0.1`). If supplied, the [`BUILD_BUILDID`](#build_buildid) will be appended to the version ID.
 
 ### `BUILD_BUILDID`
 (Optional) Suffix for LUIS version ID.
 
-When supplied the `BUILD_BUILDID` value will be appended to the [`luisVersionId`](#luisversionid) (or `0.1.1` if it's not provided). This is useful in continuous integration and deployment scenarios when you need to generate a new version ID to import a new LUIS model. 
-
-Note that the `BUILD_BUILDID` environment variable is available by default in [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) builds.
+Optional for `train`. When supplied the `BUILD_BUILDID` value will be appended to the [`luisVersionId`](#luisversionid) (or `0.1.1` if it's not provided). This is useful in continuous integration and deployment scenarios when you need to generate a new version ID to import a new LUIS model. Note that the `BUILD_BUILDID` environment variable is available by default in [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) builds.

--- a/docs/Test.md
+++ b/docs/Test.md
@@ -72,7 +72,7 @@ The resulting output will be a JSON array in the generic utterances format, with
 
 See [Generic Utterances Model](GenericUtterances.md) for more information on the JSON schema for utterances.
 
-See [LUIS Key Configuration](TODO) and [Lex Key Configuration](TODO) for more information on how to supply secrets, e.g., the endpoint key, to the CLI tool.
+See [Configuring LUIS secrets](LuisSecrets.md) and [Configuring Lex secrets](LexSecrets.md) for more information on how to supply secrets, e.g., the endpoint key, to the CLI tool.
 
 ## Getting started with speech
 
@@ -98,7 +98,7 @@ dotnet nlu test -s luis --speech -u utterances.json
 
 You do not need to train your NLU service with the NLU.DevOps CLI tool in order to test it with the tool. You can just as easily point the tool at existing trained models, e.g., on LUIS or Lex without training from the CLI tool.
 
-See [LUIS Key Configuration](LuisSecrets.md) and [Lex Key Configuration](TODO) for more information on how to point to an existing service, e.g., with a LUIS app ID.
+See [Configuring LUIS secrets](LuisSecrets.md) and [Configuring Lex secrets](LexSecrets.md) for more information on how to point to an existing service, e.g., with a LUIS app ID.
 
 ## Caching speech-to-text transcriptions
 

--- a/docs/Train.md
+++ b/docs/Train.md
@@ -41,7 +41,7 @@ The `utterances.json` argument is the path to the generic utterances file, which
 
 See [Generic Utterances Model](GenericUtterances.md) for more information on the JSON schema for utterances.
 
-See [LUIS Key Configuration](LuisSecrets.md) and [Lex Key Configuration](TODO) for more information on how to supply secrets, e.g., the authoring key, to the CLI tool.
+See [Configuring LUIS secrets](LuisSecrets.md) and [Configuring Lex secrets](LexSecrets.md) for more information on how to supply secrets, e.g., the authoring key, to the CLI tool.
 
 ## Detailed Usage
 


### PR DESCRIPTION
Includes information for the appsettings required to use the `train`, `test` and `clean` command with Lex.