### PR TITLE
The `INLUServiceFactory` interface comes from the Core DLL

### DIFF
--- a/docs/CliExtensions.md
+++ b/docs/CliExtensions.md
@@ -17,6 +17,7 @@ Be sure to replace `demo` with the service identifier you plan to use for your N
 ```bash
 cd dotnet-nlu-demo
 dotnet add package NLU.DevOps.Models
+dotnet add package NLU.DevOps.Core
 dotnet add package System.Composition.AttributedModel
 ```
 


### PR DESCRIPTION
Adds the reference to the Core project, which will be needed to consume the `INLUServiceFactory` interface.