### PR TITLE
Change ILuisClient::GetTrainingStatusAsync to return string

### DIFF
--- a/src/NLU.DevOps.Luis.Tests/LuisNLUServiceTests.cs
+++ b/src/NLU.DevOps.Luis.Tests/LuisNLUServiceTests.cs
@@ -434,16 +434,13 @@ namespace NLU.DevOps.Luis.Tests
         public static async Task TrainingStatusDelayBetweenPolling()
         {
             var count = 0;
-            string[] statusArray = { "Queued", "InProgress", "Success" };
+            ModelTrainingStatus[] statusArray = { ModelTrainingStatus.InProgress, ModelTrainingStatus.Success };
             var mockClient = new MockLuisClient();
             mockClient.OnRequestResponse = request =>
             {
                 if (IsTrainingStatusRequest(request))
                 {
-                    return new[]
-                    {
-                        statusArray[count++]
-                    };
+                    return statusArray[count++];
                 }
 
                 return null;
@@ -479,10 +476,7 @@ namespace NLU.DevOps.Luis.Tests
             {
                 if (IsTrainingStatusRequest(request))
                 {
-                    return new[]
-                    {
-                        "Fail"
-                    };
+                    return ModelTrainingStatus.Fail;
                 }
 
                 return null;
@@ -824,9 +818,9 @@ namespace NLU.DevOps.Luis.Tests
                 return this.ProcessRequestAsync(appId);
             }
 
-            public Task<IEnumerable<string>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken)
+            public Task<ModelTrainingStatus> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken)
             {
-                return this.ProcessRequestAsync<IEnumerable<string>>(appId, versionId);
+                return this.ProcessRequestAsync<ModelTrainingStatus>(appId, versionId);
             }
 
             public Task ImportVersionAsync(string appId, string versionId, LuisApp luisApp, CancellationToken cancellationToken)
@@ -878,7 +872,7 @@ namespace NLU.DevOps.Luis.Tests
                 var response = this.OnRequestResponse?.Invoke(request);
                 if (response == null && IsTrainingStatusRequest(request))
                 {
-                    response = Array.Empty<string>();
+                    response = ModelTrainingStatus.Success;
                 }
 
                 return Task.FromResult((T)response);

--- a/src/NLU.DevOps.Luis.Tests/LuisNLUServiceTests.cs
+++ b/src/NLU.DevOps.Luis.Tests/LuisNLUServiceTests.cs
@@ -4,6 +4,7 @@
 namespace NLU.DevOps.Luis.Tests
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
     using System.Runtime.CompilerServices;
@@ -441,10 +442,7 @@ namespace NLU.DevOps.Luis.Tests
                 {
                     return new[]
                     {
-                        new ModelTrainingInfo
-                        {
-                            Details = new ModelTrainingDetails { Status = statusArray[count++] }
-                        }
+                        statusArray[count++]
                     };
                 }
 
@@ -483,10 +481,7 @@ namespace NLU.DevOps.Luis.Tests
                 {
                     return new[]
                     {
-                        new ModelTrainingInfo
-                        {
-                            Details = new ModelTrainingDetails { Status = "Fail" }
-                        }
+                        "Fail"
                     };
                 }
 
@@ -829,9 +824,9 @@ namespace NLU.DevOps.Luis.Tests
                 return this.ProcessRequestAsync(appId);
             }
 
-            public Task<IList<ModelTrainingInfo>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken)
+            public Task<IEnumerable<string>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken)
             {
-                return this.ProcessRequestAsync<IList<ModelTrainingInfo>>(appId, versionId);
+                return this.ProcessRequestAsync<IEnumerable<string>>(appId, versionId);
             }
 
             public Task ImportVersionAsync(string appId, string versionId, LuisApp luisApp, CancellationToken cancellationToken)
@@ -883,7 +878,7 @@ namespace NLU.DevOps.Luis.Tests
                 var response = this.OnRequestResponse?.Invoke(request);
                 if (response == null && IsTrainingStatusRequest(request))
                 {
-                    response = Array.Empty<ModelTrainingInfo>();
+                    response = Array.Empty<string>();
                 }
 
                 return Task.FromResult((T)response);

--- a/src/NLU.DevOps.Luis/ILuisClient.cs
+++ b/src/NLU.DevOps.Luis/ILuisClient.cs
@@ -39,7 +39,7 @@ namespace NLU.DevOps.Luis
         /// <param name="appId">LUIS app ID.</param>
         /// <param name="versionId">LUIS version ID.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        Task<IEnumerable<string>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken);
+        Task<ModelTrainingStatus> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Imports the LUIS app version.

--- a/src/NLU.DevOps.Luis/ILuisClient.cs
+++ b/src/NLU.DevOps.Luis/ILuisClient.cs
@@ -39,7 +39,7 @@ namespace NLU.DevOps.Luis
         /// <param name="appId">LUIS app ID.</param>
         /// <param name="versionId">LUIS version ID.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        Task<IList<ModelTrainingInfo>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken);
+        Task<IEnumerable<string>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Imports the LUIS app version.

--- a/src/NLU.DevOps.Luis/LuisClient.cs
+++ b/src/NLU.DevOps.Luis/LuisClient.cs
@@ -5,6 +5,7 @@ namespace NLU.DevOps.Luis
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Text;
@@ -111,9 +112,10 @@ namespace NLU.DevOps.Luis
             return this.AuthoringClient.Apps.DeleteAsync(Guid.Parse(appId), cancellationToken);
         }
 
-        public Task<IList<ModelTrainingInfo>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken)
+        public async Task<IEnumerable<string>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken)
         {
-            return this.AuthoringClient.Train.GetStatusAsync(Guid.Parse(appId), versionId, cancellationToken);
+            IList<ModelTrainingInfo> modelTrainingInfos = await this.AuthoringClient.Train.GetStatusAsync(Guid.Parse(appId), versionId, cancellationToken).ConfigureAwait(false);
+            return modelTrainingInfos.Select(modelInfo => modelInfo.Details.Status);
         }
 
         public Task ImportVersionAsync(string appId, string versionId, LuisApp luisApp, CancellationToken cancellationToken)

--- a/src/NLU.DevOps.Luis/LuisClient.cs
+++ b/src/NLU.DevOps.Luis/LuisClient.cs
@@ -112,10 +112,17 @@ namespace NLU.DevOps.Luis
             return this.AuthoringClient.Apps.DeleteAsync(Guid.Parse(appId), cancellationToken);
         }
 
-        public async Task<IEnumerable<string>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken)
+        public async Task<ModelTrainingStatus> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken)
         {
             IList<ModelTrainingInfo> modelTrainingInfos = await this.AuthoringClient.Train.GetStatusAsync(Guid.Parse(appId), versionId, cancellationToken).ConfigureAwait(false);
-            return modelTrainingInfos.Select(modelInfo => modelInfo.Details.Status);
+            if (modelTrainingInfos.Any(m => m.Details.Status == "Fail"))
+            {
+                return ModelTrainingStatus.Fail;
+            }
+
+            return modelTrainingInfos.Any(m => m.Details.Status == "InProgress" || m.Details.Status == "Queued")
+                ? ModelTrainingStatus.InProgress
+                : ModelTrainingStatus.Success;
         }
 
         public Task ImportVersionAsync(string appId, string versionId, LuisApp luisApp, CancellationToken cancellationToken)

--- a/src/NLU.DevOps.Luis/LuisNLUService.cs
+++ b/src/NLU.DevOps.Luis/LuisNLUService.cs
@@ -238,12 +238,11 @@ namespace NLU.DevOps.Luis
             {
                 var trainingStatus = await this.LuisClient.GetTrainingStatusAsync(this.LuisAppId, this.LuisVersionId, cancellationToken).ConfigureAwait(false);
                 var inProgress = trainingStatus
-                    .Select(modelInfo => modelInfo.Details.Status)
                     .Any(status => status == "InProgress" || status == "Queued");
 
                 if (!inProgress)
                 {
-                    if (trainingStatus.Any(modelInfo => modelInfo.Details.Status == "Fail"))
+                    if (trainingStatus.Any(status => status == "Fail"))
                     {
                         throw new InvalidOperationException("Failure occurred while training LUIS model.");
                     }

--- a/src/NLU.DevOps.Luis/ModelTrainingStatus.cs
+++ b/src/NLU.DevOps.Luis/ModelTrainingStatus.cs
@@ -1,0 +1,23 @@
+﻿namespace NLU.DevOps.Luis
+{
+    /// <summary>
+    /// Status for Model training
+    /// </summary>
+    public enum ModelTrainingStatus
+    {
+        /// <summary>
+        /// Indicates there was a failure training the model
+        /// </summary>
+        Fail,
+
+        /// <summary>
+        /// Indicates that the model is still being trained or queued for training
+        /// </summary>
+        InProgress,
+
+        /// <summary>
+        /// Indicates successful training of the model
+        /// </summary>
+        Success
+    }
+}

--- a/src/NLU.DevOps.Luis/ModelTrainingStatus.cs
+++ b/src/NLU.DevOps.Luis/ModelTrainingStatus.cs
@@ -1,9 +1,14 @@
-﻿namespace NLU.DevOps.Luis
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.Luis
 {
+#pragma warning disable CA1717 // Only FlagsAttribute enums should have plural names
     /// <summary>
     /// Status for Model training
     /// </summary>
     public enum ModelTrainingStatus
+#pragma warning restore CA1717 // Only FlagsAttribute enums should have plural names
     {
         /// <summary>
         /// Indicates there was a failure training the model


### PR DESCRIPTION
This is the first PR in the refactors necessary for Luis V3 API support. 

GetTrainingStatusAsync returns a list of ModelTrainingInfo but only used the status strings. In an effort to make the LuisClient methods return non-LUIS-SDK models when possible, we will expand on the status strings and return an enumerable of those instead of the full object.