### PR TITLE
Split ILuisClient into two different interfaces

### DIFF
--- a/src/NLU.DevOps.Luis.Tests/LuisNLUServiceTests.cs
+++ b/src/NLU.DevOps.Luis.Tests/LuisNLUServiceTests.cs
@@ -4,6 +4,7 @@
 namespace NLU.DevOps.Luis.Tests
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
     using System.Runtime.CompilerServices;
@@ -441,10 +442,7 @@ namespace NLU.DevOps.Luis.Tests
                 {
                     return new[]
                     {
-                        new ModelTrainingInfo
-                        {
-                            Details = new ModelTrainingDetails { Status = statusArray[count++] }
-                        }
+                        statusArray[count++]
                     };
                 }
 
@@ -483,10 +481,7 @@ namespace NLU.DevOps.Luis.Tests
                 {
                     return new[]
                     {
-                        new ModelTrainingInfo
-                        {
-                            Details = new ModelTrainingDetails { Status = "Fail" }
-                        }
+                        "Fail"
                     };
                 }
 
@@ -681,9 +676,9 @@ namespace NLU.DevOps.Luis.Tests
                 return this.ProcessRequestAsync(appId);
             }
 
-            public Task<IList<ModelTrainingInfo>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken)
+            public Task<IEnumerable<string>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken)
             {
-                return this.ProcessRequestAsync<IList<ModelTrainingInfo>>(appId, versionId);
+                return this.ProcessRequestAsync<IEnumerable<string>>(appId, versionId);
             }
 
             public Task ImportVersionAsync(string appId, string versionId, LuisApp luisApp, CancellationToken cancellationToken)
@@ -735,7 +730,7 @@ namespace NLU.DevOps.Luis.Tests
                 var response = this.OnRequestResponse?.Invoke(request);
                 if (response == null && IsTrainingStatusRequest(request))
                 {
-                    response = Array.Empty<ModelTrainingInfo>();
+                    response = Array.Empty<string>();
                 }
 
                 return Task.FromResult((T)response);

--- a/src/NLU.DevOps.Luis/ILuisClient.cs
+++ b/src/NLU.DevOps.Luis/ILuisClient.cs
@@ -4,87 +4,11 @@
 namespace NLU.DevOps.Luis
 {
     using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring.Models;
-    using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.Models;
-    using Newtonsoft.Json.Linq;
 
     /// <summary>
     /// Interface for LUIS operations.
     /// </summary>
-    public interface ILuisClient : IDisposable
+    public interface ILuisClient : ILuisTrainingClient, ILuisPredictionClient, IDisposable
     {
-        /// <summary>
-        /// Creates the LUIS app.
-        /// </summary>
-        /// <returns>Task to await the LUIS app ID of the newly created app.</returns>
-        /// <param name="appName">LUIS app name.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        Task<string> CreateAppAsync(string appName, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Deletes the LUIS app.
-        /// </summary>
-        /// <returns>Task to await the delete operation.</returns>
-        /// <param name="appId">LUIS app ID.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        Task DeleteAppAsync(string appId, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Gets the training status for the LUIS app version.
-        /// </summary>
-        /// <returns>Task to await the training status response.</returns>
-        /// <param name="appId">LUIS app ID.</param>
-        /// <param name="versionId">LUIS version ID.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        Task<IEnumerable<string>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Imports the LUIS app version.
-        /// </summary>
-        /// <returns>Task to await the import operation.</returns>
-        /// <param name="appId">LUIS app ID.</param>
-        /// <param name="versionId">LUIS version ID.</param>
-        /// <param name="luisApp">LUIS app to import.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        Task ImportVersionAsync(string appId, string versionId, LuisApp luisApp, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Publishes the LUIS app version.
-        /// </summary>
-        /// <returns>Task to await the publish operation.</returns>
-        /// <param name="appId">LUIS app ID.</param>
-        /// <param name="versionId">LUIS version ID.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        Task PublishAppAsync(string appId, string versionId, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Queries the LUIS app to extract intent and entities.
-        /// </summary>
-        /// <returns>Task to await the LUIS results.</returns>
-        /// <param name="appId">LUIS app ID.</param>
-        /// <param name="text">Query text.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        Task<LuisResult> QueryAsync(string appId, string text, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Performs intent recognition from speech using the given audio file.
-        /// </summary>
-        /// <returns>Task to await the LUIS results.</returns>
-        /// <param name="appId">LUIS app ID.</param>
-        /// <param name="speechFile">Path to file.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        Task<LuisResult> RecognizeSpeechAsync(string appId, string speechFile, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Trains the LUIS app version.
-        /// </summary>
-        /// <returns>Task to await the train operation.</returns>
-        /// <param name="appId">LUIS app identifier.</param>
-        /// <param name="versionId">LUIS version ID.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        Task TrainAsync(string appId, string versionId, CancellationToken cancellationToken);
     }
 }

--- a/src/NLU.DevOps.Luis/ILuisClient.cs
+++ b/src/NLU.DevOps.Luis/ILuisClient.cs
@@ -39,7 +39,7 @@ namespace NLU.DevOps.Luis
         /// <param name="appId">LUIS app ID.</param>
         /// <param name="versionId">LUIS version ID.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        Task<IList<ModelTrainingInfo>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken);
+        Task<IEnumerable<string>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Imports the LUIS app version.

--- a/src/NLU.DevOps.Luis/ILuisPredictionClient.cs
+++ b/src/NLU.DevOps.Luis/ILuisPredictionClient.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.Luis
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.Models;
+
+    /// <summary>
+    /// Interface for LUIS Runtime operations
+    /// </summary>
+    public interface ILuisPredictionClient
+    {
+        /// <summary>
+        /// Queries the LUIS app to extract intent and entities.
+        /// </summary>
+        /// <returns>Task to await the LUIS results.</returns>
+        /// <param name="appId">LUIS app ID.</param>
+        /// <param name="text">Query text.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task<LuisResult> QueryAsync(string appId, string text, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Performs intent recognition from speech using the given audio file.
+        /// </summary>
+        /// <returns>Task to await the LUIS results.</returns>
+        /// <param name="appId">LUIS app ID.</param>
+        /// <param name="speechFile">Path to file.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task<LuisResult> RecognizeSpeechAsync(string appId, string speechFile, CancellationToken cancellationToken);
+
+    }
+}

--- a/src/NLU.DevOps.Luis/ILuisPredictionClient.cs
+++ b/src/NLU.DevOps.Luis/ILuisPredictionClient.cs
@@ -29,6 +29,5 @@ namespace NLU.DevOps.Luis
         /// <param name="speechFile">Path to file.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         Task<LuisResult> RecognizeSpeechAsync(string appId, string speechFile, CancellationToken cancellationToken);
-
     }
 }

--- a/src/NLU.DevOps.Luis/ILuisTrainingClient.cs
+++ b/src/NLU.DevOps.Luis/ILuisTrainingClient.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.Luis
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring.Models;
+
+    /// <summary>
+    /// Interface for LUIS Authoring operations
+    /// </summary>
+    public interface ILuisTrainingClient
+    {
+        /// <summary>
+        /// Creates the LUIS app.
+        /// </summary>
+        /// <returns>Task to await the LUIS app ID of the newly created app.</returns>
+        /// <param name="appName">LUIS app name.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task<string> CreateAppAsync(string appName, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Deletes the LUIS app.
+        /// </summary>
+        /// <returns>Task to await the delete operation.</returns>
+        /// <param name="appId">LUIS app ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task DeleteAppAsync(string appId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Gets the training status for the LUIS app version.
+        /// </summary>
+        /// <returns>Task to await the training status response.</returns>
+        /// <param name="appId">LUIS app ID.</param>
+        /// <param name="versionId">LUIS version ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task<IEnumerable<string>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Imports the LUIS app version.
+        /// </summary>
+        /// <returns>Task to await the import operation.</returns>
+        /// <param name="appId">LUIS app ID.</param>
+        /// <param name="versionId">LUIS version ID.</param>
+        /// <param name="luisApp">LUIS app to import.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task ImportVersionAsync(string appId, string versionId, LuisApp luisApp, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Publishes the LUIS app version.
+        /// </summary>
+        /// <returns>Task to await the publish operation.</returns>
+        /// <param name="appId">LUIS app ID.</param>
+        /// <param name="versionId">LUIS version ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task PublishAppAsync(string appId, string versionId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Trains the LUIS app version.
+        /// </summary>
+        /// <returns>Task to await the train operation.</returns>
+        /// <param name="appId">LUIS app identifier.</param>
+        /// <param name="versionId">LUIS version ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task TrainAsync(string appId, string versionId, CancellationToken cancellationToken);
+    }
+}

--- a/src/NLU.DevOps.Luis/LuisClient.cs
+++ b/src/NLU.DevOps.Luis/LuisClient.cs
@@ -7,23 +7,16 @@ namespace NLU.DevOps.Luis
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Logging;
     using Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring.Models;
-    using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime;
     using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.Models;
-    using Microsoft.CognitiveServices.Speech;
-    using Microsoft.CognitiveServices.Speech.Audio;
-    using Microsoft.CognitiveServices.Speech.Intent;
-    using Microsoft.Extensions.Logging;
-    using Newtonsoft.Json;
 
     internal class LuisClient : ILuisClient
     {
         public const string Protocol = "https://";
         public const string Domain = ".api.cognitive.microsoft.com";
 
-        private static readonly TimeSpan ThrottleQueryDelay = TimeSpan.FromMilliseconds(100);
         private readonly ILuisTrainingClient trainingClient;
+        private readonly ILuisPredictionClient predictionClient;
 
         public LuisClient(
             string authoringKey,
@@ -38,22 +31,11 @@ namespace NLU.DevOps.Luis
                 this.trainingClient = new LuisTrainingClient(authoringKey, authoringRegion, azureSubscriptionInfo, isStaging);
             }
 
-            var endpointCredentials = new ApiKeyServiceClientCredentials(endpointKey);
-            this.RuntimeClient = new LUISRuntimeClient(endpointCredentials)
+            if (endpointKey != null && endpointRegion != null)
             {
-                Endpoint = $"{Protocol}{endpointRegion}{Domain}",
-            };
-
-            this.LazySpeechConfig = new Lazy<SpeechConfig>(() => SpeechConfig.FromSubscription(endpointKey, endpointRegion));
+                this.predictionClient = new LuisPredictionClient(endpointKey, endpointRegion);
+            }
         }
-
-        private static ILogger Logger => LazyLogger.Value;
-
-        private static Lazy<ILogger> LazyLogger { get; } = new Lazy<ILogger>(() => ApplicationLogger.LoggerFactory.CreateLogger<LuisNLUService>());
-
-        private LUISRuntimeClient RuntimeClient { get; }
-
-        private Lazy<SpeechConfig> LazySpeechConfig { get; }
 
         public Task<string> CreateAppAsync(string appName, CancellationToken cancellationToken)
         {
@@ -85,52 +67,14 @@ namespace NLU.DevOps.Luis
             return this.trainingClient?.TrainAsync(appId, versionId, cancellationToken);
         }
 
-        public async Task<LuisResult> QueryAsync(string appId, string text, CancellationToken cancellationToken)
+        public Task<LuisResult> QueryAsync(string appId, string text, CancellationToken cancellationToken)
         {
-            while (true)
-            {
-                try
-                {
-                    return await this.RuntimeClient.Prediction.ResolveAsync(appId, text, cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
-                catch (APIErrorException ex)
-                when ((int)ex.Response.StatusCode == 429)
-                {
-                    Logger.LogWarning("Received HTTP 429 result from Cognitive Services. Retrying.");
-                    await Task.Delay(ThrottleQueryDelay, cancellationToken).ConfigureAwait(false);
-                }
-            }
+            return this.predictionClient?.QueryAsync(appId, text, cancellationToken);
         }
 
-        public virtual async Task<LuisResult> RecognizeSpeechAsync(string appId, string speechFile, CancellationToken cancellationToken)
+        public virtual Task<LuisResult> RecognizeSpeechAsync(string appId, string speechFile, CancellationToken cancellationToken)
         {
-            using (var audioInput = AudioConfig.FromWavFileInput(speechFile))
-            using (var recognizer = new IntentRecognizer(this.LazySpeechConfig.Value, audioInput))
-            {
-                // Add intents to intent recognizer
-                var model = LanguageUnderstandingModel.FromAppId(appId);
-                recognizer.AddIntent(model, "None", "None");
-                var result = await recognizer.RecognizeOnceAsync().ConfigureAwait(false);
-
-                // Checks result.
-                // For some reason RecognizeOnceAsync always return ResultReason.RecognizedSpeech
-                // when intent is recognized. It's because we don't add all possible intents (note that this IS intentional)
-                // in code via AddIntent method.
-                if (result.Reason == ResultReason.RecognizedSpeech || result.Reason == ResultReason.RecognizedIntent)
-                {
-                    var content = result.Properties.GetProperty(PropertyId.LanguageUnderstandingServiceResponse_JsonResult);
-                    return JsonConvert.DeserializeObject<LuisResult>(content);
-                }
-                else if (result.Reason == ResultReason.NoMatch)
-                {
-                    Logger.LogWarning("Received 'NoMatch' result from Cognitive Services.");
-                    return null;
-                }
-                else
-                {
-                    throw new InvalidOperationException($"Failed to get speech recognition result. Reason = '{result.Reason}'");
-                }
-            }
+            return this.predictionClient?.RecognizeSpeechAsync(appId, speechFile, cancellationToken);
         }
 
         public void Dispose()
@@ -144,10 +88,7 @@ namespace NLU.DevOps.Luis
             if (disposing)
             {
                 (this.trainingClient as IDisposable)?.Dispose();
-
-                using (this.RuntimeClient)
-                {
-                }
+                (this.predictionClient as IDisposable)?.Dispose();
             }
         }
     }

--- a/src/NLU.DevOps.Luis/LuisClient.cs
+++ b/src/NLU.DevOps.Luis/LuisClient.cs
@@ -5,14 +5,9 @@ namespace NLU.DevOps.Luis
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
-    using System.Net;
-    using System.Net.Http;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Logging;
-    using Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring;
     using Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring.Models;
     using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime;
     using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.Models;
@@ -24,10 +19,11 @@ namespace NLU.DevOps.Luis
 
     internal class LuisClient : ILuisClient
     {
-        private const string Protocol = "https://";
-        private const string Domain = ".api.cognitive.microsoft.com";
+        public const string Protocol = "https://";
+        public const string Domain = ".api.cognitive.microsoft.com";
 
         private static readonly TimeSpan ThrottleQueryDelay = TimeSpan.FromMilliseconds(100);
+        private readonly ILuisTrainingClient trainingClient;
 
         public LuisClient(
             string authoringKey,
@@ -37,32 +33,16 @@ namespace NLU.DevOps.Luis
             AzureSubscriptionInfo azureSubscriptionInfo,
             bool isStaging)
         {
-            this.IsStaging = isStaging;
+            if (authoringKey != null && authoringRegion != null)
+            {
+                this.trainingClient = new LuisTrainingClient(authoringKey, authoringRegion, azureSubscriptionInfo, isStaging);
+            }
 
-            var endpointOrAuthoringKey = endpointKey ?? authoringKey ?? throw new ArgumentException($"Must specify either '{nameof(authoringKey)}' or '{nameof(endpointKey)}'.");
-            this.EndpointRegion = endpointRegion ?? authoringRegion ?? throw new ArgumentException($"Must specify either '{nameof(authoringRegion)}' or '{nameof(endpointRegion)}'.");
-            this.AzureSubscriptionInfo = azureSubscriptionInfo;
-            this.AuthoringKey = authoringKey;
-
-            var endpointCredentials = new Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.ApiKeyServiceClientCredentials(endpointOrAuthoringKey);
+            var endpointCredentials = new ApiKeyServiceClientCredentials(endpointKey);
             this.RuntimeClient = new LUISRuntimeClient(endpointCredentials)
             {
-                Endpoint = $"{Protocol}{this.EndpointRegion}{Domain}",
+                Endpoint = $"{Protocol}{endpointRegion}{Domain}",
             };
-
-            this.LazyAuthoringClient = new Lazy<LUISAuthoringClient>(() =>
-            {
-                if (authoringKey == null || authoringRegion == null)
-                {
-                    throw new InvalidOperationException("Must provide authoring key and region to perform authoring operations.");
-                }
-
-                var authoringCredentials = new Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring.ApiKeyServiceClientCredentials(authoringKey);
-                return new LUISAuthoringClient(authoringCredentials)
-                {
-                    Endpoint = $"{Protocol}{authoringRegion}{Domain}",
-                };
-            });
 
             this.LazySpeechConfig = new Lazy<SpeechConfig>(() => SpeechConfig.FromSubscription(endpointKey, endpointRegion));
         }
@@ -71,68 +51,38 @@ namespace NLU.DevOps.Luis
 
         private static Lazy<ILogger> LazyLogger { get; } = new Lazy<ILogger>(() => ApplicationLogger.LoggerFactory.CreateLogger<LuisNLUService>());
 
-        private string EndpointRegion { get; }
-
-        private AzureSubscriptionInfo AzureSubscriptionInfo { get; }
-
-        private string AuthoringKey { get; }
-
-        private bool IsStaging { get; }
-
         private LUISRuntimeClient RuntimeClient { get; }
-
-        private LUISAuthoringClient AuthoringClient => this.LazyAuthoringClient.Value;
-
-        private Lazy<LUISAuthoringClient> LazyAuthoringClient { get; }
 
         private Lazy<SpeechConfig> LazySpeechConfig { get; }
 
-        public async Task<string> CreateAppAsync(string appName, CancellationToken cancellationToken)
+        public Task<string> CreateAppAsync(string appName, CancellationToken cancellationToken)
         {
-            var request = new ApplicationCreateObject
-            {
-                Name = appName,
-                Culture = "en-us",
-            };
-
-            // Creating LUIS app.
-            var appId = await this.AuthoringClient.Apps.AddAsync(request, cancellationToken).ConfigureAwait(false);
-
-            // Assign Azure resource to LUIS app.
-            if (this.AzureSubscriptionInfo != null)
-            {
-                await this.AssignAzureResourceAsync(appId).ConfigureAwait(false);
-            }
-
-            return appId.ToString();
+            return this.trainingClient?.CreateAppAsync(appName, cancellationToken);
         }
 
         public Task DeleteAppAsync(string appId, CancellationToken cancellationToken)
         {
-            return this.AuthoringClient.Apps.DeleteAsync(Guid.Parse(appId), cancellationToken);
+            return this.trainingClient?.DeleteAppAsync(appId, cancellationToken);
         }
 
-        public async Task<IEnumerable<string>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken)
+        public Task<IEnumerable<string>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken)
         {
-            IList<ModelTrainingInfo> modelTrainingInfos = await this.AuthoringClient.Train.GetStatusAsync(Guid.Parse(appId), versionId, cancellationToken).ConfigureAwait(false);
-            return modelTrainingInfos.Select(modelInfo => modelInfo.Details.Status);
+            return this.trainingClient?.GetTrainingStatusAsync(appId, versionId, cancellationToken);
         }
 
         public Task ImportVersionAsync(string appId, string versionId, LuisApp luisApp, CancellationToken cancellationToken)
         {
-            return this.AuthoringClient.Versions.ImportAsync(Guid.Parse(appId), luisApp, versionId, cancellationToken);
+            return this.trainingClient?.ImportVersionAsync(appId, versionId, luisApp, cancellationToken);
         }
 
         public Task PublishAppAsync(string appId, string versionId, CancellationToken cancellationToken)
         {
-            var request = new ApplicationPublishObject
-            {
-                IsStaging = this.IsStaging,
-                Region = this.EndpointRegion,
-                VersionId = versionId,
-            };
+            return this.trainingClient?.PublishAppAsync(appId, versionId, cancellationToken);
+        }
 
-            return this.AuthoringClient.Apps.PublishAsync(Guid.Parse(appId), request, cancellationToken);
+        public Task TrainAsync(string appId, string versionId, CancellationToken cancellationToken)
+        {
+            return this.trainingClient?.TrainAsync(appId, versionId, cancellationToken);
         }
 
         public async Task<LuisResult> QueryAsync(string appId, string text, CancellationToken cancellationToken)
@@ -183,11 +133,6 @@ namespace NLU.DevOps.Luis
             }
         }
 
-        public Task TrainAsync(string appId, string versionId, CancellationToken cancellationToken)
-        {
-            return this.AuthoringClient.Train.TrainVersionAsync(Guid.Parse(appId), versionId, cancellationToken);
-        }
-
         public void Dispose()
         {
             this.Dispose(true);
@@ -198,32 +143,12 @@ namespace NLU.DevOps.Luis
         {
             if (disposing)
             {
-                using (this.AuthoringClient)
+                (this.trainingClient as IDisposable)?.Dispose();
+
                 using (this.RuntimeClient)
                 {
                 }
             }
-        }
-
-        private async Task AssignAzureResourceAsync(Guid appId)
-        {
-            var jsonBody = JsonConvert.SerializeObject(this.AzureSubscriptionInfo);
-            var data = new StringContent(jsonBody, Encoding.UTF8, "application/json");
-            var url = $"{this.AuthoringClient.Endpoint}/luis/api/v2.0/apps/{appId}/azureaccounts";
-            var request = new HttpRequestMessage
-            {
-                Method = HttpMethod.Post,
-                RequestUri = new Uri(url),
-                Headers =
-                {
-                    { HttpRequestHeader.Authorization.ToString(), $"Bearer {this.AzureSubscriptionInfo.ArmToken}" },
-                    { "Ocp-Apim-Subscription-Key", this.AuthoringKey }
-                },
-                Content = data,
-            };
-
-            var result = await this.AuthoringClient.HttpClient.SendAsync(request).ConfigureAwait(false);
-            result.EnsureSuccessStatusCode();
         }
     }
 }

--- a/src/NLU.DevOps.Luis/LuisClient.cs
+++ b/src/NLU.DevOps.Luis/LuisClient.cs
@@ -5,6 +5,7 @@ namespace NLU.DevOps.Luis
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Text;
@@ -111,9 +112,10 @@ namespace NLU.DevOps.Luis
             return this.AuthoringClient.Apps.DeleteAsync(Guid.Parse(appId), cancellationToken);
         }
 
-        public Task<IList<ModelTrainingInfo>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken)
+        public async Task<IEnumerable<string>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken)
         {
-            return this.AuthoringClient.Train.GetStatusAsync(Guid.Parse(appId), versionId, cancellationToken);
+            IList<ModelTrainingInfo> modelTrainingInfos = await this.AuthoringClient.Train.GetStatusAsync(Guid.Parse(appId), versionId, cancellationToken).ConfigureAwait(false);
+            return modelTrainingInfos.Select(modelInfo => modelInfo.Details.Status);
         }
 
         public Task ImportVersionAsync(string appId, string versionId, LuisApp luisApp, CancellationToken cancellationToken)

--- a/src/NLU.DevOps.Luis/LuisNLUService.cs
+++ b/src/NLU.DevOps.Luis/LuisNLUService.cs
@@ -238,12 +238,11 @@ namespace NLU.DevOps.Luis
             {
                 var trainingStatus = await this.LuisClient.GetTrainingStatusAsync(this.LuisAppId, this.LuisVersionId, cancellationToken).ConfigureAwait(false);
                 var inProgress = trainingStatus
-                    .Select(modelInfo => modelInfo.Details.Status)
                     .Any(status => status == "InProgress" || status == "Queued");
 
                 if (!inProgress)
                 {
-                    if (trainingStatus.Any(modelInfo => modelInfo.Details.Status == "Fail"))
+                    if (trainingStatus.Any(status => status == "Fail"))
                     {
                         throw new InvalidOperationException("Failure occurred while training LUIS model.");
                     }

--- a/src/NLU.DevOps.Luis/LuisPredictionClient.cs
+++ b/src/NLU.DevOps.Luis/LuisPredictionClient.cs
@@ -1,0 +1,91 @@
+﻿namespace NLU.DevOps.Luis
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Logging;
+    using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime;
+    using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.Models;
+    using Microsoft.CognitiveServices.Speech;
+    using Microsoft.CognitiveServices.Speech.Audio;
+    using Microsoft.CognitiveServices.Speech.Intent;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+
+    internal sealed class LuisPredictionClient : ILuisPredictionClient, IDisposable
+    {
+        private static readonly TimeSpan ThrottleQueryDelay = TimeSpan.FromMilliseconds(100);
+
+        public LuisPredictionClient(string endpointKey, string endpointRegion)
+        {
+
+            var endpointCredentials = new ApiKeyServiceClientCredentials(endpointKey);
+            this.RuntimeClient = new LUISRuntimeClient(endpointCredentials)
+            {
+                Endpoint = $"{LuisClient.Protocol}{endpointRegion}{LuisClient.Domain}",
+            };
+            this.LazySpeechConfig = new Lazy<SpeechConfig>(() => SpeechConfig.FromSubscription(endpointKey, endpointRegion));
+        }
+
+        private static ILogger Logger => LazyLogger.Value;
+
+        private static Lazy<ILogger> LazyLogger { get; } = new Lazy<ILogger>(() => ApplicationLogger.LoggerFactory.CreateLogger<LuisNLUService>());
+
+        private LUISRuntimeClient RuntimeClient { get; }
+
+        private Lazy<SpeechConfig> LazySpeechConfig { get; }
+
+        public async Task<LuisResult> QueryAsync(string appId, string text, CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                try
+                {
+                    return await this.RuntimeClient.Prediction.ResolveAsync(appId, text, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                catch (APIErrorException ex)
+                    when ((int)ex.Response.StatusCode == 429)
+                {
+                    Logger.LogWarning("Received HTTP 429 result from Cognitive Services. Retrying.");
+                    await Task.Delay(ThrottleQueryDelay, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        public async Task<LuisResult> RecognizeSpeechAsync(string appId, string speechFile, CancellationToken cancellationToken)
+        {
+            using (var audioInput = AudioConfig.FromWavFileInput(speechFile))
+            using (var recognizer = new IntentRecognizer(this.LazySpeechConfig.Value, audioInput))
+            {
+                // Add intents to intent recognizer
+                var model = LanguageUnderstandingModel.FromAppId(appId);
+                recognizer.AddIntent(model, "None", "None");
+                var result = await recognizer.RecognizeOnceAsync().ConfigureAwait(false);
+
+                // Checks result.
+                // For some reason RecognizeOnceAsync always return ResultReason.RecognizedSpeech
+                // when intent is recognized. It's because we don't add all possible intents (note that this IS intentional)
+                // in code via AddIntent method.
+                if (result.Reason == ResultReason.RecognizedSpeech || result.Reason == ResultReason.RecognizedIntent)
+                {
+                    var content = result.Properties.GetProperty(PropertyId.LanguageUnderstandingServiceResponse_JsonResult);
+                    return JsonConvert.DeserializeObject<LuisResult>(content);
+                }
+                else if (result.Reason == ResultReason.NoMatch)
+                {
+                    Logger.LogWarning("Received 'NoMatch' result from Cognitive Services.");
+                    return null;
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Failed to get speech recognition result. Reason = '{result.Reason}'");
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            this.RuntimeClient?.Dispose();
+        }
+    }
+}

--- a/src/NLU.DevOps.Luis/LuisPredictionClient.cs
+++ b/src/NLU.DevOps.Luis/LuisPredictionClient.cs
@@ -1,4 +1,7 @@
-﻿namespace NLU.DevOps.Luis
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.Luis
 {
     using System;
     using System.Threading;
@@ -18,7 +21,6 @@
 
         public LuisPredictionClient(string endpointKey, string endpointRegion)
         {
-
             var endpointCredentials = new ApiKeyServiceClientCredentials(endpointKey);
             this.RuntimeClient = new LUISRuntimeClient(endpointCredentials)
             {

--- a/src/NLU.DevOps.Luis/LuisTrainingClient.cs
+++ b/src/NLU.DevOps.Luis/LuisTrainingClient.cs
@@ -15,7 +15,7 @@ namespace NLU.DevOps.Luis
     using Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring.Models;
     using Newtonsoft.Json;
 
-    internal class LuisTrainingClient : ILuisTrainingClient, IDisposable
+    internal sealed class LuisTrainingClient : ILuisTrainingClient, IDisposable
     {
         public LuisTrainingClient(string authoringKey, string authoringRegion, AzureSubscriptionInfo azureSubscriptionInfo, bool isStaging)
         {

--- a/src/NLU.DevOps.Luis/LuisTrainingClient.cs
+++ b/src/NLU.DevOps.Luis/LuisTrainingClient.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.Luis
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring;
+    using Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring.Models;
+    using Newtonsoft.Json;
+
+    internal class LuisTrainingClient : ILuisTrainingClient, IDisposable
+    {
+        public LuisTrainingClient(string authoringKey, string authoringRegion, AzureSubscriptionInfo azureSubscriptionInfo, bool isStaging)
+        {
+            this.IsStaging = isStaging;
+
+            this.AuthoringKey = authoringKey ?? throw new ArgumentNullException(nameof(authoringKey));
+            this.EndpointRegion = authoringRegion ?? throw new ArgumentNullException(nameof(authoringRegion));
+            this.AzureSubscriptionInfo = azureSubscriptionInfo;
+            this.LazyAuthoringClient = new Lazy<LUISAuthoringClient>(() =>
+            {
+                var authoringCredentials =
+                    new ApiKeyServiceClientCredentials(authoringKey);
+                return new LUISAuthoringClient(authoringCredentials)
+                {
+                    Endpoint = $"{LuisClient.Protocol}{authoringRegion}{LuisClient.Domain}",
+                };
+            });
+            ;
+        }
+
+        private string EndpointRegion { get; set; }
+
+        private AzureSubscriptionInfo AzureSubscriptionInfo { get; set; }
+
+        private string AuthoringKey { get; set; }
+
+        private bool IsStaging { get; set; }
+
+        private LUISAuthoringClient AuthoringClient => this.LazyAuthoringClient.Value;
+
+        private Lazy<LUISAuthoringClient> LazyAuthoringClient { get; set; }
+
+        public async Task<string> CreateAppAsync(string appName, CancellationToken cancellationToken)
+        {
+            var request = new ApplicationCreateObject
+            {
+                Name = appName,
+                Culture = "en-us",
+            };
+
+            // Creating LUIS app.
+            var appId = await this.AuthoringClient.Apps.AddAsync(request, cancellationToken).ConfigureAwait(false);
+
+            // Assign Azure resource to LUIS app.
+            if (this.AzureSubscriptionInfo != null)
+            {
+                await this.AssignAzureResourceAsync(appId).ConfigureAwait(false);
+            }
+
+            return appId.ToString();
+        }
+
+        public Task DeleteAppAsync(string appId, CancellationToken cancellationToken)
+        {
+            return this.AuthoringClient.Apps.DeleteAsync(Guid.Parse(appId), cancellationToken);
+        }
+
+        public async Task<IEnumerable<string>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken)
+        {
+            IList<ModelTrainingInfo> modelTrainingInfos = await this.AuthoringClient.Train.GetStatusAsync(Guid.Parse(appId), versionId, cancellationToken).ConfigureAwait(false);
+            return modelTrainingInfos.Select(modelInfo => modelInfo.Details.Status);
+        }
+
+        public Task ImportVersionAsync(string appId, string versionId, LuisApp luisApp, CancellationToken cancellationToken)
+        {
+            return this.AuthoringClient.Versions.ImportAsync(Guid.Parse(appId), luisApp, versionId, cancellationToken);
+        }
+
+        public Task PublishAppAsync(string appId, string versionId, CancellationToken cancellationToken)
+        {
+            var request = new ApplicationPublishObject
+            {
+                IsStaging = this.IsStaging,
+                Region = this.EndpointRegion,
+                VersionId = versionId,
+            };
+
+            return this.AuthoringClient.Apps.PublishAsync(Guid.Parse(appId), request, cancellationToken);
+        }
+
+        public Task TrainAsync(string appId, string versionId, CancellationToken cancellationToken)
+        {
+            return this.AuthoringClient.Train.TrainVersionAsync(Guid.Parse(appId), versionId, cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            this.AuthoringClient.Dispose();
+        }
+
+        private async Task AssignAzureResourceAsync(Guid appId)
+        {
+            var jsonBody = JsonConvert.SerializeObject(this.AzureSubscriptionInfo);
+            var data = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+            var url = $"{this.AuthoringClient.Endpoint}/luis/api/v2.0/apps/{appId}/azureaccounts";
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                RequestUri = new Uri(url),
+                Headers =
+                {
+                    { HttpRequestHeader.Authorization.ToString(), $"Bearer {this.AzureSubscriptionInfo.ArmToken}" },
+                    { "Ocp-Apim-Subscription-Key", this.AuthoringKey }
+                },
+                Content = data,
+            };
+
+            var result = await this.AuthoringClient.HttpClient.SendAsync(request).ConfigureAwait(false);
+            result.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/src/NLU.DevOps.Luis/LuisTrainingClient.cs
+++ b/src/NLU.DevOps.Luis/LuisTrainingClient.cs
@@ -33,20 +33,19 @@ namespace NLU.DevOps.Luis
                     Endpoint = $"{LuisClient.Protocol}{authoringRegion}{LuisClient.Domain}",
                 };
             });
-            ;
         }
 
-        private string EndpointRegion { get; set; }
+        private string EndpointRegion { get; }
 
-        private AzureSubscriptionInfo AzureSubscriptionInfo { get; set; }
+        private AzureSubscriptionInfo AzureSubscriptionInfo { get; }
 
-        private string AuthoringKey { get; set; }
+        private string AuthoringKey { get; }
 
-        private bool IsStaging { get; set; }
+        private bool IsStaging { get; }
 
         private LUISAuthoringClient AuthoringClient => this.LazyAuthoringClient.Value;
 
-        private Lazy<LUISAuthoringClient> LazyAuthoringClient { get; set; }
+        private Lazy<LUISAuthoringClient> LazyAuthoringClient { get; }
 
         public async Task<string> CreateAppAsync(string appName, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
In Luis V3, the prediction (query) SDK has many changes, but the authoring portion seems to be mostly the same (as of current versions). In an effort to re-use as much code as possible between the two versions, ILuisClient will need to be split into two different interfaces, one for the authoring components and the other for Runtime. To avoid confusion between the interface names, the interfaces are named ILuisTrainingClient (Authoring) and ILuisPredictionClient (Runtime).

The ILuisClient interface and LuisClient implementation are unchanged so as not to break existing functionality or make the refactor bigger than it has to be, though that is something that can happen later. For the moment it just forwards on to the proper implementation class.