### PR TITLE
Build from current branch when running the NLU pipeline

### DIFF
--- a/pipelines/nlu.yml
+++ b/pipelines/nlu.yml
@@ -10,11 +10,20 @@ trigger:
   
 steps:
 - task: DotNetCoreCLI@2
+  displayName: Create NuGet package for NLU.DevOps.CommandLine
+  inputs:
+    command: pack
+    packagesToPack: 'src/NLU.DevOps.CommandLine/*.csproj'
+    configuration: Release
+
+- task: DotNetCoreCLI@2
   displayName: Install dotnet-nlu
   inputs:
     command: custom
     custom: tool
-    arguments: install dotnet-nlu --tool-path $(Agent.TempDirectory)/bin
+    arguments: install dotnet-nlu --add-source $(Build.ArtifactStagingDirectory) --tool-path $(Agent.TempDirectory)/bin
+    # Unless you've forked NLU.DevOps and are building from source, you can just install 'dotnet-nlu' from NuGet:
+    # arguments: install dotnet-nlu --tool-path $(Agent.TempDirectory)/bin
 
 - bash: echo "##vso[task.prependpath]$(Agent.TempDirectory)/bin"
   displayName: Prepend .NET Core CLI tool path


### PR DESCRIPTION
The nlu.yml pipeline is useful for end-to-end testing with LUIS. This change builds and packs the CLI project and installs to the .NET CLI.