### PR TITLE
Adds functionality to include LUIS confidence scores

### DIFF
--- a/src/NLU.DevOps.Luis/ScoredEntity.cs
+++ b/src/NLU.DevOps.Luis/ScoredEntity.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.Luis
+{
+    using Models;
+
+    /// <summary>
+    /// Entity appearing in utterance with confidence score.
+    /// </summary>
+    public class ScoredEntity : Entity
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScoredEntity"/> class.
+        /// </summary>
+        /// <param name="entityType">Entity type name.</param>
+        /// <param name="entityValue">Entity value, generally a canonical form of the entity.</param>
+        /// <param name="matchText">Matching text in the utterance.</param>
+        /// <param name="matchIndex">Occurrence index of matching token in the utterance.</param>
+        /// <param name="score">Confidence score for the entity.</param>
+        public ScoredEntity(string entityType, string entityValue, string matchText, int matchIndex, double score)
+            : base(entityType, entityValue, matchText, matchIndex)
+        {
+            this.Score = score;
+        }
+
+        /// <summary>
+        /// Gets the confidence score for the entity.
+        /// </summary>
+        public double Score { get; }
+    }
+}

--- a/src/NLU.DevOps.Luis/ScoredLabeledUtterance.cs
+++ b/src/NLU.DevOps.Luis/ScoredLabeledUtterance.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.Luis
+{
+    using System.Collections.Generic;
+    using Models;
+
+    /// <summary>
+    /// Labeled utterance with confidence score.
+    /// </summary>
+    public class ScoredLabeledUtterance : LabeledUtterance
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScoredLabeledUtterance"/> class.
+        /// </summary>
+        /// <param name="text">Text of the utterance.</param>
+        /// <param name="intent">Intent of the utterance.</param>
+        /// <param name="score">Confidence score for the intent label.</param>
+        /// <param name="entities">Entities referenced in the utterance.</param>
+        public ScoredLabeledUtterance(string text, string intent, double score, IReadOnlyList<Entity> entities)
+            : base(text, intent, entities)
+        {
+            this.Score = score;
+        }
+
+        /// <summary>
+        /// Gets the entities referenced in the utterance.
+        /// </summary>
+        public new IReadOnlyList<ScoredEntity> Entities => (IReadOnlyList<ScoredEntity>)base.Entities;
+
+        /// <summary>
+        /// Gets the confidence score for the intent label.
+        /// </summary>
+        public double Score { get; }
+    }
+}

--- a/src/NLU.DevOps.Luis/ScoredLabeledUtterance.cs
+++ b/src/NLU.DevOps.Luis/ScoredLabeledUtterance.cs
@@ -25,11 +25,6 @@ namespace NLU.DevOps.Luis
         }
 
         /// <summary>
-        /// Gets the entities referenced in the utterance.
-        /// </summary>
-        public new IReadOnlyList<ScoredEntity> Entities => (IReadOnlyList<ScoredEntity>)base.Entities;
-
-        /// <summary>
         /// Gets the confidence score for the intent label.
         /// </summary>
         public double Score { get; }


### PR DESCRIPTION
The NLUService instance for LUIS currently drops the confidence scores for intents and entities. This change ensures those scores show up when results are serialized in the NLU.DevOps command line, so we can use the score values for deeper analysis of performance.