### PR TITLE
Ensures matching entities have the expected type

### DIFF
--- a/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSource.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSource.cs
@@ -191,7 +191,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
             {
                 return expectedEntity.EntityType == actualEntity.EntityType
                     && (EqualsNormalized(expectedEntity.MatchText, actualEntity.MatchText)
-                    // Required case to support NLU providers that do not specify matched text
+                    /* Required case to support NLU providers that do not specify matched text */
                     || EqualsNormalized(expectedEntity.MatchText, actualEntity.EntityValue)
                     || EqualsNormalized(expectedEntity.EntityValue, actualEntity.EntityValue));
             }

--- a/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSource.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSource.cs
@@ -190,9 +190,9 @@ namespace NLU.DevOps.ModelPerformance.Tests
             bool isEntityMatch(Entity expectedEntity, Entity actualEntity)
             {
                 return expectedEntity.EntityType == actualEntity.EntityType
-                    && EqualsNormalized(expectedEntity.MatchText, actualEntity.MatchText)
+                    && (EqualsNormalized(expectedEntity.MatchText, actualEntity.MatchText)
                     || EqualsNormalized(expectedEntity.MatchText, actualEntity.EntityValue)
-                    || EqualsNormalized(expectedEntity.EntityValue, actualEntity.EntityValue);
+                    || EqualsNormalized(expectedEntity.EntityValue, actualEntity.EntityValue));
             }
 
             if (expected != null)

--- a/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSource.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSource.cs
@@ -191,6 +191,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
             {
                 return expectedEntity.EntityType == actualEntity.EntityType
                     && (EqualsNormalized(expectedEntity.MatchText, actualEntity.MatchText)
+                    // Required case to support NLU providers that do not specify matched text
                     || EqualsNormalized(expectedEntity.MatchText, actualEntity.EntityValue)
                     || EqualsNormalized(expectedEntity.EntityValue, actualEntity.EntityValue));
             }


### PR DESCRIPTION
Previously, we were only checking for entity text match. This change reports a `FalsePositive` result when the entity is correct, but the detected type is incorrect.