### PR TITLE
Removes unnecessary restore step from pipelines

### DIFF
--- a/pipelines/build.yml
+++ b/pipelines/build.yml
@@ -15,12 +15,6 @@ trigger:
     
 steps:
 - task: DotNetCoreCLI@2
-  displayName: Restore NuGet packages
-  inputs:
-    command: 'restore'
-    projects: 'src/NLU.DevOps.sln'
-
-- task: DotNetCoreCLI@2
   displayName: Build solution
   inputs:
     projects: 'src/NLU.DevOps.sln'

--- a/pipelines/nlu.yml
+++ b/pipelines/nlu.yml
@@ -10,12 +10,6 @@ trigger:
   
 steps:
 - task: DotNetCoreCLI@2
-  displayName: Restore NuGet packages
-  inputs:
-    command: 'restore'
-    projects: 'src/NLU.DevOps.sln'
-
-- task: DotNetCoreCLI@2
   displayName: Build NLU.DevOps solution
   inputs:
     projects: 'src/NLU.DevOps.sln'


### PR DESCRIPTION
Using the build task for .NET Core already restores the packages.