### PR TITLE
Fixes environment variable export in ARM token task

### DIFF
--- a/pipelines/nlu.yml
+++ b/pipelines/nlu.yml
@@ -40,15 +40,20 @@ steps:
 - bash: echo "##vso[task.prependpath]$(Agent.TempDirectory)/bin"
   displayName: Prepend .NET Core CLI tool path
 
-- task: AzureCLI@1
+- task: AzurePowerShell@4
   displayName: 'Get ARM token for Azure'
   condition: and(succeeded(), ne(variables['nlu.ci'], 'false'))
   inputs:
     azureSubscription: $(azureSubscription)
-    scriptLocation: inlineScript
-    inlineScript: |
-      ACCESS_TOKEN="$(az account get-access-token --query accessToken -o tsv)";
-      echo "##vso[task.setvariable variable=arm_token]${ACCESS_TOKEN}"
+    azurePowerShellVersion: 'latestVersion'
+    scriptType: 'inlineScript'
+    inline: |
+      $azProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile
+      $currentAzureContext = Get-AzContext
+      $profileClient = New-Object Microsoft.Azure.Commands.ResourceManager.Common.RMProfileClient($azProfile)
+      $token = $profileClient.AcquireAccessToken($currentAzureContext.Tenant.TenantId)
+      $setVariableMessage = "##vso[task.setvariable variable=arm_token]{0}" -f $token.AccessToken 
+      echo $setVariableMessage
 
 - task: DotNetCoreCLI@2
   displayName: Train the NLU service


### PR DESCRIPTION
We were previously using Linux based build agents to run the NLU test pipeline. Now that we are using Windows, we need to use `set` to export environment variables.