### PR TITLE
Temporary fix to get LUIS v2 Speech SDK working on Windows

### DIFF
--- a/pipelines/nlu.yml
+++ b/pipelines/nlu.yml
@@ -16,14 +16,14 @@ steps:
 - task: DotNetCoreCLI@2
   displayName: Build NLU.DevOps solution
   inputs:
-    projects: 'src/NLU.DevOps.sln'
-    arguments: '--configuration Release /warnaserror'
+    projects: src/NLU.DevOps.sln
+    arguments: --configuration Release /warnaserror
 
 - task: DotNetCoreCLI@2
   displayName: Create NuGet package for NLU.DevOps.CommandLine
   inputs:
     command: pack
-    packagesToPack: 'src/NLU.DevOps.CommandLine/*.csproj'
+    packagesToPack: src/NLU.DevOps.CommandLine/*.csproj
     configuration: Release
 
 - task: DotNetCoreCLI@2
@@ -39,12 +39,12 @@ steps:
   displayName: Prepend .NET Core CLI tool path
 
 - task: AzurePowerShell@4
-  displayName: 'Get ARM token for Azure'
+  displayName: Get ARM token for Azure
   condition: and(succeeded(), ne(variables['nlu.ci'], 'false'))
   inputs:
     azureSubscription: $(azureSubscription)
-    azurePowerShellVersion: 'latestVersion'
-    scriptType: 'inlineScript'
+    azurePowerShellVersion: latestVersion
+    scriptType: inlineScript
     inline: |
       $azProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile
       $currentAzureContext = Get-AzContext
@@ -88,7 +88,7 @@ steps:
       --utterances models/tests.speech.json
       --speech-directory $(recordingsDirectory)
       --service-settings models/settings.$(nlu.service).json
-      --output $(Agent.TempDirectory)/speech/results.speech.json
+      --output $(Agent.TempDirectory)/speech/results.json
 
 - task: DotNetCoreCLI@2
   displayName: Cleanup the NLU service
@@ -116,8 +116,8 @@ steps:
     command: custom
     custom: nlu
     arguments: compare
-      --expected models/tests.json
-      --actual $(Agent.TempDirectory)/speech/results.speech.json
+      --expected models/tests.speech.json
+      --actual $(Agent.TempDirectory)/speech/results.json
       --output-folder $(Build.ArtifactStagingDirectory)/speech
 
 - task: DotNetCoreCLI@2
@@ -131,7 +131,7 @@ steps:
   displayName: Publish test results
   inputs:
     testResultsFormat: NUnit
-    testResultsFiles: $(Build.ArtifactStagingDirectory)/TestResult.xml
+    testResultsFiles: $(Build.ArtifactStagingDirectory)/*/TestResult.xml
 
 - task: PublishBuildArtifacts@1
   condition: and(succeeded(), ne(variables['nlu.ci'], 'false'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
@@ -165,4 +165,4 @@ steps:
   displayName: Check for performance regression
   inputs:
     scriptPath: scripts/compare.py
-    arguments: $(Agent.TempDirectory)/drop/TestResult.xml $(Build.ArtifactStagingDirectory)/text/TestResult.xml
+    arguments: $(Agent.TempDirectory)/drop/*/TestResult.xml $(Build.ArtifactStagingDirectory)/*/TestResult.xml

--- a/pipelines/nlu.yml
+++ b/pipelines/nlu.yml
@@ -23,7 +23,7 @@ steps:
   displayName: Create NuGet package for NLU.DevOps.CommandLine
   inputs:
     command: pack
-    packagesToPack: src/NLU.DevOps.CommandLine/*.csproj
+    packagesToPack: src/NLU.DevOps.CommandLine
     configuration: Release
 
 - task: DotNetCoreCLI@2

--- a/src/NLU.DevOps.CommandLine/NLU.DevOps.CommandLine.csproj
+++ b/src/NLU.DevOps.CommandLine/NLU.DevOps.CommandLine.csproj
@@ -43,5 +43,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="NUnitLite" Version="3.11.0" />
     <PackageReference Include="System.Composition" Version="1.2.0" />
+    <!-- temporary hack until we can resolve the native dependency for Microsoft.CognitiveServices.Speech from the NLU.DevOps.Luis plugin -->
+    <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.1.0" />
   </ItemGroup>
 </Project>

--- a/src/NLU.DevOps.CommandLine/ServiceResolver.cs
+++ b/src/NLU.DevOps.CommandLine/ServiceResolver.cs
@@ -76,17 +76,6 @@ namespace NLU.DevOps.CommandLine
                 return this.LoadFromAssemblyPath(assemblyPath);
             }
 
-            protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
-            {
-                var assemblyPath = Path.Combine(this.ProviderDirectory, $"{unmanagedDllName}");
-                if (!File.Exists(assemblyPath))
-                {
-                    return IntPtr.Zero;
-                }
-
-                return this.LoadUnmanagedDllFromPath(assemblyPath);
-            }
-
             private static bool HasDefaultAssembly(AssemblyName assemblyName)
             {
                 try

--- a/src/NLU.DevOps.Luis.Shared/ILuisConfiguration.cs
+++ b/src/NLU.DevOps.Luis.Shared/ILuisConfiguration.cs
@@ -56,6 +56,11 @@ namespace NLU.DevOps.Luis
         string SpeechKey { get; }
 
         /// <summary>
+        /// Gets the Cognitive Services speech region.
+        /// </summary>
+        string SpeechRegion { get; }
+
+        /// <summary>
         /// Gets the Cognitive Services speech endpoint.
         /// </summary>
         Uri SpeechEndpoint { get; }

--- a/src/NLU.DevOps.Luis.Shared/LuisConfiguration.cs
+++ b/src/NLU.DevOps.Luis.Shared/LuisConfiguration.cs
@@ -32,7 +32,7 @@ namespace NLU.DevOps.Luis
         private const string SpeechRegionConfigurationKey = "speechRegion";
         private const string CustomSpeechAppIdConfigurationKey = "customSpeechAppId";
 #if LUIS_V2
-        private const string LuisUseSpeechEndpoint = "luisUseSpeechEndpoint";
+        private const string LuisUseSpeechEndpointConfigurationKey = "luisUseSpeechEndpoint";
 #endif
 #if LUIS_V3
         private const string LuisSlotNameConfigurationKey = "luisSlotName";
@@ -88,15 +88,22 @@ namespace NLU.DevOps.Luis
         /// <inheritdoc />
         public string SpeechKey => this.EnsureConfigurationString(
             SpeechKeyConfigurationKey,
-            LuisEndpointKeyConfigurationKey,
-            LuisAuthoringKeyConfigurationKey);
+            LuisEndpointKeyConfigurationKey);
+
+        /// <inheritdoc />
+        public string SpeechRegion => this.EnsureConfigurationString(
+            SpeechRegionConfigurationKey,
+            LuisEndpointRegionConfigurationKey);
 
         /// <inheritdoc />
         public Uri SpeechEndpoint => this.GetSpeechEndpoint();
 #if LUIS_V2
 
         /// <inheritdoc />
-        public bool UseSpeechEndpoint => this.GetConfigurationBoolean(LuisUseSpeechEndpoint);
+        public bool UseSpeechEndpoint =>
+            this.GetConfigurationBoolean(LuisUseSpeechEndpointConfigurationKey) ||
+            this.CustomSpeechAppId != null;
+
 #endif
 #if LUIS_V3
 
@@ -123,11 +130,6 @@ namespace NLU.DevOps.Luis
         private IConfiguration Configuration { get; }
 
         private Lazy<string> LazyAppName { get; }
-
-        private string SpeechRegion => this.EnsureConfigurationString(
-            SpeechRegionConfigurationKey,
-            LuisEndpointRegionConfigurationKey,
-            LuisAuthoringRegionConfigurationKey);
 
         private string CustomSpeechAppId => this.Configuration[CustomSpeechAppIdConfigurationKey];
 

--- a/src/NLU.DevOps.Luis.Shared/NLU.DevOps.Luis.Shared.projitems
+++ b/src/NLU.DevOps.Luis.Shared/NLU.DevOps.Luis.Shared.projitems
@@ -9,14 +9,14 @@
     <Import_RootNamespace>NLU.DevOps.Luis</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)ILuisTrainClient.cs" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
-    <Compile Include="$(MSBuildThisFileDirectory)AzureSubscriptionInfo.cs" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
-    <Compile Include="$(MSBuildThisFileDirectory)LabeledUtteranceExtensions.cs" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
-    <Compile Include="$(MSBuildThisFileDirectory)LuisTrainClient.cs" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
-    <Compile Include="$(MSBuildThisFileDirectory)LuisSettings.cs" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
-    <Compile Include="$(MSBuildThisFileDirectory)LuisNLUTrainClient.cs" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
-    <Compile Include="$(MSBuildThisFileDirectory)ScoredEntity.cs" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
-    <Compile Include="$(MSBuildThisFileDirectory)ScoredLabeledUtterance.cs" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
+    <Compile Include="$(MSBuildThisFileDirectory)ILuisTrainClient.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AzureSubscriptionInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)LabeledUtteranceExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)LuisTrainClient.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)LuisSettings.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)LuisNLUTrainClient.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ScoredEntity.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ScoredLabeledUtterance.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LuisConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ILuisConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestLuisConfiguration.cs" />

--- a/src/NLU.DevOps.Luis.Tests.Shared/LuisConfigurationTests.cs
+++ b/src/NLU.DevOps.Luis.Tests.Shared/LuisConfigurationTests.cs
@@ -98,6 +98,7 @@ namespace NLU.DevOps.Luis.Tests
         [TestCase(nameof(ILuisConfiguration.AuthoringRegion), "luisAuthoringRegion")]
         [TestCase(nameof(ILuisConfiguration.EndpointKey), "luisEndpointKey", "luisAuthoringKey")]
         [TestCase(nameof(ILuisConfiguration.EndpointRegion), "luisEndpointRegion", "luisAuthoringRegion")]
+        [TestCase(nameof(ILuisConfiguration.SpeechRegion), "speechRegion", "luisEndpointRegion")]
         [TestCase(nameof(ILuisConfiguration.SpeechKey), "speechKey")]
         public static void ThrowsInvalidOperationForMissingConfiguration(string propertyName, params string[] configurationKeys)
         {
@@ -246,6 +247,22 @@ namespace NLU.DevOps.Luis.Tests
                     @"https://{0}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language=en-US",
                     speechRegion));
         }
+#if LUIS_V2
+
+        [Test]
+        public static void UseSpeechEndpointWithCustomSpeechAppId()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "customSpeechAppId", Guid.NewGuid().ToString() },
+                })
+                .Build();
+
+            var luisConfiguration = new LuisConfiguration(configuration);
+            luisConfiguration.UseSpeechEndpoint.Should().BeTrue();
+        }
+#endif
 #if LUIS_V3
 
         [Test]

--- a/src/NLU.DevOps.Luis.Tests.Shared/NLU.DevOps.Luis.Tests.Shared.projitems
+++ b/src/NLU.DevOps.Luis.Tests.Shared/NLU.DevOps.Luis.Tests.Shared.projitems
@@ -11,7 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)LuisConfigurationTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestLuisConfigurationTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)LuisNLUTrainClientTests.cs" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
-    <Compile Include="$(MSBuildThisFileDirectory)LuisNLUClientFactoryTests.cs" Condition=" '$(EnableDefaultCompileItems)' == 'true' " />
+    <Compile Include="$(MSBuildThisFileDirectory)LuisNLUTrainClientTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)LuisNLUClientFactoryTests.cs" />
   </ItemGroup>
 </Project>

--- a/src/NLU.DevOps.Luis/LuisTestClient.cs
+++ b/src/NLU.DevOps.Luis/LuisTestClient.cs
@@ -75,7 +75,7 @@ namespace NLU.DevOps.Luis
 
         private async Task<LuisResult> RecognizeSpeechWithIntentRecognizerAsync(string speechFile)
         {
-            var speechConfig = SpeechConfig.FromEndpoint(this.LuisConfiguration.SpeechEndpoint, this.LuisConfiguration.EndpointKey);
+            var speechConfig = SpeechConfig.FromSubscription(this.LuisConfiguration.SpeechKey, this.LuisConfiguration.SpeechRegion);
             using (var audioInput = AudioConfig.FromWavFileInput(speechFile))
             using (var recognizer = new IntentRecognizer(speechConfig, audioInput))
             {

--- a/src/NLU.DevOps.sln
+++ b/src/NLU.DevOps.sln
@@ -37,6 +37,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLU.DevOps.CommandLine.Tests", "NLU.DevOps.CommandLine.Tests\NLU.DevOps.CommandLine.Tests.csproj", "{1F5ADDE0-4414-4B49-9810-69B58EED51AF}"
 EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		NLU.DevOps.Luis.Shared\NLU.DevOps.Luis.Shared.projitems*{03cc905a-48d1-466c-a816-e19bf944a7ee}*SharedItemsImports = 13
+		NLU.DevOps.Luis.Tests.Shared\NLU.DevOps.Luis.Tests.Shared.projitems*{d7f8ef09-9289-432d-9255-677844f96a5b}*SharedItemsImports = 13
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -46,6 +50,10 @@ Global
 		{6B6B7069-F43F-43AD-87EB-7F0B7583404E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6B6B7069-F43F-43AD-87EB-7F0B7583404E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6B6B7069-F43F-43AD-87EB-7F0B7583404E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC9970B5-9DA3-4F7F-8C6C-EE3F2DA2DDCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC9970B5-9DA3-4F7F-8C6C-EE3F2DA2DDCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC9970B5-9DA3-4F7F-8C6C-EE3F2DA2DDCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC9970B5-9DA3-4F7F-8C6C-EE3F2DA2DDCC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{26972FE8-130F-479B-B8A5-58BC8DD7A308}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{26972FE8-130F-479B-B8A5-58BC8DD7A308}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{26972FE8-130F-479B-B8A5-58BC8DD7A308}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -82,10 +90,6 @@ Global
 		{ED09E7CE-E721-415A-A0CA-1B928EC4E7A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ED09E7CE-E721-415A-A0CA-1B928EC4E7A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ED09E7CE-E721-415A-A0CA-1B928EC4E7A0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{CC9970B5-9DA3-4F7F-8C6C-EE3F2DA2DDCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CC9970B5-9DA3-4F7F-8C6C-EE3F2DA2DDCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CC9970B5-9DA3-4F7F-8C6C-EE3F2DA2DDCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{CC9970B5-9DA3-4F7F-8C6C-EE3F2DA2DDCC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1F5ADDE0-4414-4B49-9810-69B58EED51AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1F5ADDE0-4414-4B49-9810-69B58EED51AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1F5ADDE0-4414-4B49-9810-69B58EED51AF}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Until we have a solution using AssemblyLoadContext, taking a direct dependency on Microsoft.CognitiveServices.Speech from NLU.DevOps.CommandLine so the speech SDK, including its native dependencies, is loaded correctly.