### PR TITLE
Adds statistics to NLU.DevOps.Compare

### DIFF
--- a/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
@@ -14,6 +14,7 @@ namespace NLU.DevOps.CommandLine.Compare
     internal static class CompareCommand
     {
         private const string TestMetadataFileName = "metadata.json";
+        private const string TestStatisticsFileName = "statistics.json";
 
         public static int Run(CompareOptions options)
         {
@@ -32,9 +33,11 @@ namespace NLU.DevOps.CommandLine.Compare
             {
                 var expectedUtterances = Read<List<LabeledUtterance>>(options.ExpectedUtterancesPath);
                 var actualUtterances = Read<List<LabeledUtterance>>(options.ExpectedUtterancesPath);
-                var testCases = TestCaseSource.GenerateTestCases(expectedUtterances, actualUtterances);
-                var outputFile = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestMetadataFileName) : TestMetadataFileName;
-                Write(outputFile, testCases);
+                var compareResults = TestCaseSource.GetNLUCompareResults(expectedUtterances, actualUtterances);
+                var metadataPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestMetadataFileName) : TestMetadataFileName;
+                var statisticsPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestStatisticsFileName) : TestStatisticsFileName;
+                Write(metadataPath, compareResults.TestCases);
+                Write(statisticsPath, compareResults.Statistics);
             }
             else
             {

--- a/src/NLU.DevOps.ModelPerformance/ConfusionMatrix.cs
+++ b/src/NLU.DevOps.ModelPerformance/ConfusionMatrix.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.ModelPerformance
+{
+    /// <summary>
+    /// Confusion matrix container.
+    /// </summary>
+    public class ConfusionMatrix
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfusionMatrix"/> class.
+        /// </summary>
+        /// <param name="truePositive">True positive count.</param>
+        /// <param name="trueNegative">True negative count.</param>
+        /// <param name="falsePositive">False positive count.</param>
+        /// <param name="falseNegative">False negative count.</param>
+        public ConfusionMatrix(
+            int truePositive,
+            int trueNegative,
+            int falsePositive,
+            int falseNegative)
+        {
+            this.TruePositive = truePositive;
+            this.TrueNegative = trueNegative;
+            this.FalsePositive = falsePositive;
+            this.FalseNegative = falseNegative;
+        }
+
+        /// <summary>
+        /// Gets the true positive count.
+        /// </summary>
+        public int TruePositive { get; }
+
+        /// <summary>
+        /// Gets the true negative count.
+        /// </summary>
+        public int TrueNegative { get; }
+
+        /// <summary>
+        /// Gets the false positive count.
+        /// </summary>
+        public int FalsePositive { get; }
+
+        /// <summary>
+        /// Gets the false negative count.
+        /// </summary>
+        public int FalseNegative { get; }
+    }
+}

--- a/src/NLU.DevOps.ModelPerformance/NLUCompareResults.cs
+++ b/src/NLU.DevOps.ModelPerformance/NLUCompareResults.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.ModelPerformance
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// NLU compare results.
+    /// </summary>
+    public class NLUCompareResults
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NLUCompareResults"/> class.
+        /// </summary>
+        /// <param name="testCases">Test cases.</param>
+        public NLUCompareResults(IReadOnlyList<TestCase> testCases)
+        {
+            this.TestCases = testCases;
+            this.LazyStatistics = new Lazy<NLUStatistics>(this.CalculateStatistics);
+        }
+
+        /// <summary>
+        /// Gets the test cases.
+        /// </summary>
+        public IReadOnlyList<TestCase> TestCases { get; }
+
+        /// <summary>
+        /// Gets the test case statistics.
+        /// </summary>
+        public NLUStatistics Statistics => this.LazyStatistics.Value;
+
+        private Lazy<NLUStatistics> LazyStatistics { get; }
+
+        private static ConfusionMatrix CalculateConfusionMatrix(IEnumerable<TestCase> testCases)
+        {
+            var groups = testCases
+                .GroupBy(testCase => testCase.ResultKind)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.Count());
+
+            return new ConfusionMatrix(
+                GetValueOrDefault(groups, ConfusionMatrixResultKind.TruePositive),
+                GetValueOrDefault(groups, ConfusionMatrixResultKind.TrueNegative),
+                GetValueOrDefault(groups, ConfusionMatrixResultKind.FalsePositive),
+                GetValueOrDefault(groups, ConfusionMatrixResultKind.FalseNegative));
+        }
+
+        private static TValue GetValueOrDefault<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
+        {
+            return dictionary.TryGetValue(key, out var value)
+                ? value
+                : default(TValue);
+        }
+
+        private NLUStatistics CalculateStatistics()
+        {
+            return new NLUStatistics(
+                CalculateConfusionMatrix(this.TestCases.Where(testCase => testCase.TargetKind == ComparisonTargetKind.Text)),
+                CalculateConfusionMatrix(this.TestCases.Where(testCase => testCase.TargetKind == ComparisonTargetKind.Intent)),
+                CalculateConfusionMatrix(this.TestCases.Where(testCase => testCase.TargetKind == ComparisonTargetKind.Entity)),
+                CalculateConfusionMatrix(this.TestCases.Where(testCase => testCase.TargetKind == ComparisonTargetKind.EntityValue)),
+                CalculateConfusionMatrix(this.TestCases.Where(testCase => testCase.TargetKind == ComparisonTargetKind.EntityResolution)),
+                this.TestCases
+                    .Where(testCase => testCase.Group != null)
+                    .Where(testCase => testCase.TargetKind == ComparisonTargetKind.Intent)
+                    .GroupBy(testCase => testCase.Group)
+                    .ToDictionary(group => group.Key, group => CalculateConfusionMatrix(group)),
+                this.TestCases
+                    .Where(testCase => testCase.Group != null)
+                    .Where(testCase => testCase.TargetKind == ComparisonTargetKind.Entity)
+                    .GroupBy(testCase => testCase.Group)
+                    .ToDictionary(group => group.Key, group => CalculateConfusionMatrix(group)),
+                this.TestCases
+                    .Where(testCase => testCase.Group != null)
+                    .Where(testCase => testCase.TargetKind == ComparisonTargetKind.EntityValue)
+                    .GroupBy(testCase => testCase.Group)
+                    .ToDictionary(group => group.Key, group => CalculateConfusionMatrix(group)),
+                this.TestCases
+                    .Where(testCase => testCase.Group != null)
+                    .Where(testCase => testCase.TargetKind == ComparisonTargetKind.EntityResolution)
+                    .GroupBy(testCase => testCase.Group)
+                    .ToDictionary(group => group.Key, group => CalculateConfusionMatrix(group)));
+        }
+    }
+}

--- a/src/NLU.DevOps.ModelPerformance/NLUStatistics.cs
+++ b/src/NLU.DevOps.ModelPerformance/NLUStatistics.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.ModelPerformance
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// NLU statistics.
+    /// </summary>
+    public class NLUStatistics
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NLUStatistics"/> class.
+        /// </summary>
+        /// <param name="text">Text confusion matrix.</param>
+        /// <param name="intent">Intent confusion matrix.</param>
+        /// <param name="entity">Entity confusion matrix.</param>
+        /// <param name="entityValue">Entity value confusion matrix.</param>
+        /// <param name="entityResolution">Entity resolution confusion matrix.</param>
+        /// <param name="byIntent">By intent confusion matrix.</param>
+        /// <param name="byEntityType">By entity type confusion matrix.</param>
+        /// <param name="byEntityValueType">By entity value type confusion matrix.</param>
+        /// <param name="byEntityResolutionType">By entity resolution type confusion matrix.</param>
+        public NLUStatistics(
+            ConfusionMatrix text,
+            ConfusionMatrix intent,
+            ConfusionMatrix entity,
+            ConfusionMatrix entityValue,
+            ConfusionMatrix entityResolution,
+            IReadOnlyDictionary<string, ConfusionMatrix> byIntent,
+            IReadOnlyDictionary<string, ConfusionMatrix> byEntityType,
+            IReadOnlyDictionary<string, ConfusionMatrix> byEntityValueType,
+            IReadOnlyDictionary<string, ConfusionMatrix> byEntityResolutionType)
+        {
+            this.Text = text;
+            this.Intent = intent;
+            this.Entity = entity;
+            this.EntityValue = entityValue;
+            this.EntityResolution = entityResolution;
+            this.ByIntent = byIntent;
+            this.ByEntityType = byEntityType;
+            this.ByEntityValueType = byEntityValueType;
+            this.ByEntityResolutionType = byEntityResolutionType;
+        }
+
+        /// <summary>
+        /// Gets the text confusion matrix.
+        /// </summary>
+        public ConfusionMatrix Text { get; }
+
+        /// <summary>
+        /// Gets the intent confusion matrix.
+        /// </summary>
+        public ConfusionMatrix Intent { get; }
+
+        /// <summary>
+        /// Gets the entity confusion matrix.
+        /// </summary>
+        public ConfusionMatrix Entity { get; }
+
+        /// <summary>
+        /// Gets the entity value confusion matrix.
+        /// </summary>
+        public ConfusionMatrix EntityValue { get; }
+
+        /// <summary>
+        /// Gets the entity resolution confusion matrix.
+        /// </summary>
+        public ConfusionMatrix EntityResolution { get; }
+
+        /// <summary>
+        /// Gets the intent confusion matrix by intent.
+        /// </summary>
+        public IReadOnlyDictionary<string, ConfusionMatrix> ByIntent { get; }
+
+        /// <summary>
+        /// Gets the entity confusion matrix by entity type.
+        /// </summary>
+        public IReadOnlyDictionary<string, ConfusionMatrix> ByEntityType { get; }
+
+        /// <summary>
+        /// Gets the entity value confusion matrix by entity type.
+        /// </summary>
+        public IReadOnlyDictionary<string, ConfusionMatrix> ByEntityValueType { get; }
+
+        /// <summary>
+        /// Gets the type of the by entity resolution confusion matrix by entity type.
+        /// </summary>
+        public IReadOnlyDictionary<string, ConfusionMatrix> ByEntityResolutionType { get; }
+    }
+}

--- a/src/NLU.DevOps.ModelPerformance/TestCase.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestCase.cs
@@ -19,6 +19,7 @@ namespace NLU.DevOps.ModelPerformance
         /// <param name="targetKind">Comparison target kind.</param>
         /// <param name="expectedUtterance">Expected utterance.</param>
         /// <param name="actualUtterance">Actual utterance.</param>
+        /// <param name="group">Test case group name.</param>
         /// <param name="testName">Test name.</param>
         /// <param name="because">Because.</param>
         /// <param name="categories">Categories.</param>
@@ -27,6 +28,7 @@ namespace NLU.DevOps.ModelPerformance
             ComparisonTargetKind targetKind,
             LabeledUtterance expectedUtterance,
             LabeledUtterance actualUtterance,
+            string group,
             string testName,
             string because,
             IEnumerable<string> categories)
@@ -35,6 +37,7 @@ namespace NLU.DevOps.ModelPerformance
             this.TargetKind = targetKind;
             this.ExpectedUtterance = expectedUtterance;
             this.ActualUtterance = actualUtterance;
+            this.Group = group;
             this.TestName = testName;
             this.Because = because;
             this.Categories = categories.ToList();
@@ -44,6 +47,11 @@ namespace NLU.DevOps.ModelPerformance
         /// Gets the test name.
         /// </summary>
         public string TestName { get; }
+
+        /// <summary>
+        /// Gets the test case group name.
+        /// </summary>
+        public string Group { get; }
 
         /// <summary>
         /// Gets the kind of the confusion matrix result.


### PR DESCRIPTION
In order to support efficient retrieval of NLU comparison results from multiple builds, we need to get the confusion matrix output from each build, rather than grabbing all test results from each build.

This changeset adds the statistics calculation and output for the confusion matrix broken down by all texts, intents, entities, and entity values, as well as the intents by intent and entities / entity values by type.