### PR TITLE
Set assembly version for NLU.DevOps.[Model|Core]

### DIFF
--- a/src/NLU.DevOps.Core/NLU.DevOps.Core.csproj
+++ b/src/NLU.DevOps.Core/NLU.DevOps.Core.csproj
@@ -3,6 +3,7 @@
   <Import Project="..\CodeAnalysis.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyVersion>0.2.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">

--- a/src/NLU.DevOps.Models/NLU.DevOps.Models.csproj
+++ b/src/NLU.DevOps.Models/NLU.DevOps.Models.csproj
@@ -3,6 +3,7 @@
   <Import Project="..\CodeAnalysis.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyVersion>0.2.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">


### PR DESCRIPTION
As long as their are no breaking changes, we should fix the assembly version of NLU.DevOps.Model and NLU.DevOps.Core so other projects can rely on a consistent assembly version.