### PR TITLE
Switches to PluginLoader from custom assembly resolution

### DIFF
--- a/src/NLU.DevOps.CommandLine/NLU.DevOps.CommandLine.csproj
+++ b/src/NLU.DevOps.CommandLine/NLU.DevOps.CommandLine.csproj
@@ -42,14 +42,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.5.0" />
+    <PackageReference Include="McMaster.NETCore.Plugins" Version="0.2.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="NUnitLite" Version="3.11.0" />
     <PackageReference Include="System.Composition" Version="1.2.0" />
-    <!-- temporary hack until we can resolve the native dependencies -->
-    <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.6.0" />
-    <PackageReference Include="Google.Cloud.Dialogflow.V2" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/src/NLU.DevOps.CommandLine/ServiceResolver.cs
+++ b/src/NLU.DevOps.CommandLine/ServiceResolver.cs
@@ -9,6 +9,7 @@ namespace NLU.DevOps.CommandLine
     using System.Linq;
     using System.Reflection;
     using System.Runtime.Loader;
+    using McMaster.NETCore.Plugins;
 
     internal static class ServiceResolver
     {
@@ -17,10 +18,11 @@ namespace NLU.DevOps.CommandLine
             string getAssemblyPath()
             {
                 var assemblyName = $"dotnet-nlu-{options.Service}.dll";
-                var defaultSearchPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "providers", options.Service, assemblyName);
-                if (File.Exists(defaultSearchPath))
+                var defaultSearchPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "providers");
+                var defaultAssemblyPath = Directory.GetFiles(defaultSearchPath, assemblyName, SearchOption.AllDirectories).FirstOrDefault();
+                if (defaultAssemblyPath != null)
                 {
-                    return defaultSearchPath;
+                    return defaultAssemblyPath;
                 }
 
                 var paths = new string[9];
@@ -43,52 +45,14 @@ namespace NLU.DevOps.CommandLine
                 return false;
             }
 
-            var providerDirectory = Path.GetDirectoryName(assemblyPath);
-            var assemblyLoadContext = new ProviderAssemblyLoadContext(providerDirectory);
+            var assembly = PluginLoader.CreateFromAssemblyFile(
+                    assemblyPath,
+                    PluginLoaderOptions.PreferSharedTypes)
+                .LoadDefaultAssembly();
             return new ContainerConfiguration()
-               .WithAssembly(assemblyLoadContext.LoadFromAssemblyPath(assemblyPath))
+               .WithAssembly(assembly)
                .CreateContainer()
                .TryGetExport(options.Service, out instance);
-        }
-
-        private class ProviderAssemblyLoadContext : AssemblyLoadContext
-        {
-            public ProviderAssemblyLoadContext(string providerDirectory)
-            {
-                this.ProviderDirectory = providerDirectory;
-            }
-
-            private string ProviderDirectory { get; }
-
-            protected override Assembly Load(AssemblyName assemblyName)
-            {
-                if (HasDefaultAssembly(assemblyName))
-                {
-                    return null;
-                }
-
-                var assemblyPath = Path.Combine(this.ProviderDirectory, $"{assemblyName.Name}.dll");
-                if (!File.Exists(assemblyPath))
-                {
-                    return null;
-                }
-
-                return this.LoadFromAssemblyPath(assemblyPath);
-            }
-
-            private static bool HasDefaultAssembly(AssemblyName assemblyName)
-            {
-                try
-                {
-                    return Default.LoadFromAssemblyName(assemblyName) != null;
-                }
-                catch (Exception)
-                {
-                    // Swallow exceptions from default context
-                }
-
-                return false;
-            }
         }
     }
 }

--- a/src/NLU.DevOps.DialogFlow/NLU.DevOps.DialogFlow.csproj
+++ b/src/NLU.DevOps.DialogFlow/NLU.DevOps.DialogFlow.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <AssemblyName>dotnet-nlu-dialogflow</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>

--- a/src/NLU.DevOps.Lex.Tests/NLU.DevOps.Lex.Tests.csproj
+++ b/src/NLU.DevOps.Lex.Tests/NLU.DevOps.Lex.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CodeAnalysis.props" />
   <Import Project="..\CodeCoverage.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">

--- a/src/NLU.DevOps.Lex/NLU.DevOps.Lex.csproj
+++ b/src/NLU.DevOps.Lex/NLU.DevOps.Lex.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CodeAnalysis.props" />
   <PropertyGroup>
     <AssemblyName>dotnet-nlu-lex</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>

--- a/src/NLU.DevOps.Luis.Tests/NLU.DevOps.Luis.Tests.csproj
+++ b/src/NLU.DevOps.Luis.Tests/NLU.DevOps.Luis.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CodeCoverage.props" />
   <Import Project="..\CodeAnalysis.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DefineConstants>$(DefineConstants);LUIS_V2</DefineConstants>
   </PropertyGroup>
 

--- a/src/NLU.DevOps.Luis/NLU.DevOps.Luis.csproj
+++ b/src/NLU.DevOps.Luis/NLU.DevOps.Luis.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CodeAnalysis.props" />
   <PropertyGroup>
     <AssemblyName>dotnet-nlu-luis</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <DefineConstants>$(DefineConstants);LUIS_V2</DefineConstants>

--- a/src/NLU.DevOps.LuisV3.Tests/NLU.DevOps.LuisV3.Tests.csproj
+++ b/src/NLU.DevOps.LuisV3.Tests/NLU.DevOps.LuisV3.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CodeCoverage.props" />
   <Import Project="..\CodeAnalysis.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DefineConstants>$(DefineConstants);LUIS_V3</DefineConstants>
   </PropertyGroup>
 

--- a/src/NLU.DevOps.LuisV3/NLU.DevOps.LuisV3.csproj
+++ b/src/NLU.DevOps.LuisV3/NLU.DevOps.LuisV3.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CodeAnalysis.props" />
   <PropertyGroup>
     <AssemblyName>dotnet-nlu-luisV3</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <RootNamespace>NLU.DevOps.Luis</RootNamespace>


### PR DESCRIPTION
Previously, we created a custom AssemblyLoadContext that had limitations for loading native libraries. This change switches to McMaster.NETCore.Plugins for more robust dynamic assembly loading.