### PR TITLE
Always output NUnit results from compare command

### DIFF
--- a/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
@@ -39,10 +39,8 @@ namespace NLU.DevOps.CommandLine.Compare
                 Write(metadataPath, compareResults.TestCases);
                 Write(statisticsPath, compareResults.Statistics);
             }
-            else
-            {
-                new AutoRun(typeof(ConfigurationConstants).Assembly).Execute(arguments.ToArray());
-            }
+
+            new AutoRun(typeof(ConfigurationConstants).Assembly).Execute(arguments.ToArray());
 
             // We don't care if there are any failing NUnit tests
             return 0;


### PR DESCRIPTION
Previously, the `compare` command could either output NUnit results or JSON metadata. This change ensures that NUnit test results are always generated.