### PR TITLE
Removes unused Logger properties and reduces log output

### DIFF
--- a/src/NLU.DevOps.Luis.Shared/LuisTrainClient.cs
+++ b/src/NLU.DevOps.Luis.Shared/LuisTrainClient.cs
@@ -10,10 +10,8 @@ namespace NLU.DevOps.Luis
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using Logging;
     using Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring;
     using Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring.Models;
-    using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
 
     internal class LuisTrainClient : ILuisTrainClient
@@ -30,10 +28,6 @@ namespace NLU.DevOps.Luis
                 Endpoint = $"{Protocol}{luisConfiguration.AuthoringRegion}{Domain}",
             };
         }
-
-        private static ILogger Logger => LazyLogger.Value;
-
-        private static Lazy<ILogger> LazyLogger { get; } = new Lazy<ILogger>(() => ApplicationLogger.LoggerFactory.CreateLogger<LuisNLUTrainClient>());
 
         private ILuisConfiguration LuisConfiguration { get; }
 

--- a/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
@@ -10,9 +10,7 @@ namespace NLU.DevOps.Luis
     using System.Threading;
     using System.Threading.Tasks;
     using Core;
-    using Logging;
     using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.Models;
-    using Microsoft.Extensions.Logging;
     using Models;
     using Newtonsoft.Json.Linq;
 
@@ -32,10 +30,6 @@ namespace NLU.DevOps.Luis
             this.LuisSettings = luisSettings ?? throw new ArgumentNullException(nameof(luisSettings));
             this.LuisClient = luisClient ?? throw new ArgumentNullException(nameof(luisClient));
         }
-
-        private static ILogger Logger => LazyLogger.Value;
-
-        private static Lazy<ILogger> LazyLogger { get; } = new Lazy<ILogger>(() => ApplicationLogger.LoggerFactory.CreateLogger<LuisNLUTestClient>());
 
         private LuisSettings LuisSettings { get; }
 

--- a/src/NLU.DevOps.LuisV3/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.LuisV3/LuisNLUTestClient.cs
@@ -8,10 +8,7 @@ namespace NLU.DevOps.Luis
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using Core;
-    using Logging;
     using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.Models;
-    using Microsoft.Extensions.Logging;
     using Models;
     using Newtonsoft.Json.Linq;
 
@@ -31,10 +28,6 @@ namespace NLU.DevOps.Luis
             this.LuisSettings = luisSettings ?? throw new ArgumentNullException(nameof(luisSettings));
             this.LuisClient = luisClient ?? throw new ArgumentNullException(nameof(luisClient));
         }
-
-        private static ILogger Logger => LazyLogger.Value;
-
-        private static Lazy<ILogger> LazyLogger { get; } = new Lazy<ILogger>(() => ApplicationLogger.LoggerFactory.CreateLogger<LuisNLUTestClient>());
 
         private LuisSettings LuisSettings { get; }
 


### PR DESCRIPTION
Removes occurrences of Logger static property where it's not being used, and ensures that the query target (slot or direct version) in LUIS v3 is logged only once.