### PR TITLE
Updates NLU.DevOps.ModelPerformance to pass through utterance JSON

### DIFF
--- a/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
@@ -32,7 +32,7 @@ namespace NLU.DevOps.CommandLine.Compare
             if (options.Metadata)
             {
                 var expectedUtterances = Read<List<LabeledUtterance>>(options.ExpectedUtterancesPath);
-                var actualUtterances = Read<List<LabeledUtterance>>(options.ExpectedUtterancesPath);
+                var actualUtterances = Read<List<ScoredLabeledUtterance>>(options.ExpectedUtterancesPath);
                 var compareResults = TestCaseSource.GetNLUCompareResults(expectedUtterances, actualUtterances);
                 var metadataPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestMetadataFileName) : TestMetadataFileName;
                 var statisticsPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestStatisticsFileName) : TestStatisticsFileName;

--- a/src/NLU.DevOps.Luis/ILuisTestClient.cs
+++ b/src/NLU.DevOps.Luis/ILuisTestClient.cs
@@ -27,6 +27,6 @@ namespace NLU.DevOps.Luis
         /// <returns>Task to await the LUIS results.</returns>
         /// <param name="speechFile">Path to file.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        Task<LuisResult> RecognizeSpeechAsync(string speechFile, CancellationToken cancellationToken);
+        Task<SpeechLuisResult> RecognizeSpeechAsync(string speechFile, CancellationToken cancellationToken);
     }
 }

--- a/src/NLU.DevOps.Luis/SpeechLuisResult.cs
+++ b/src/NLU.DevOps.Luis/SpeechLuisResult.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.Luis
+{
+    using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.Models;
+
+    /// <summary>
+    /// LUIS response including speech confidence score.
+    /// </summary>
+    public class SpeechLuisResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpeechLuisResult"/> class.
+        /// </summary>
+        /// <param name="luisResult">Luis result.</param>
+        /// <param name="textScore">Text score.</param>
+        public SpeechLuisResult(LuisResult luisResult, double textScore)
+        {
+            this.LuisResult = luisResult;
+            this.TextScore = textScore;
+        }
+
+        /// <summary>
+        /// Gets the LUIS result.
+        /// </summary>
+        public LuisResult LuisResult { get; }
+
+        /// <summary>
+        /// Gets the text score.
+        /// </summary>
+        public double TextScore { get; }
+    }
+}

--- a/src/NLU.DevOps.LuisV3/ILuisTestClient.cs
+++ b/src/NLU.DevOps.LuisV3/ILuisTestClient.cs
@@ -28,6 +28,6 @@ namespace NLU.DevOps.Luis
         /// <param name="speechFile">Path to file.</param>
         /// <param name="predictionRequest">Prediction request.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        Task<PredictionResponse> RecognizeSpeechAsync(string speechFile, PredictionRequest predictionRequest, CancellationToken cancellationToken);
+        Task<SpeechPredictionResponse> RecognizeSpeechAsync(string speechFile, PredictionRequest predictionRequest, CancellationToken cancellationToken);
     }
 }

--- a/src/NLU.DevOps.LuisV3/LuisTestClient.cs
+++ b/src/NLU.DevOps.LuisV3/LuisTestClient.cs
@@ -76,7 +76,7 @@ namespace NLU.DevOps.Luis
             }
         }
 
-        public async Task<PredictionResponse> RecognizeSpeechAsync(string speechFile, PredictionRequest predictionRequest, CancellationToken cancellationToken)
+        public async Task<SpeechPredictionResponse> RecognizeSpeechAsync(string speechFile, PredictionRequest predictionRequest, CancellationToken cancellationToken)
         {
             if (this.LuisConfiguration.SpeechKey == null)
             {
@@ -117,7 +117,9 @@ namespace NLU.DevOps.Luis
                 Options = predictionRequest?.Options,
             };
 
-            return await this.QueryAsync(speechPredictionRequest, cancellationToken).ConfigureAwait(false);
+            var predictionResponse = await this.QueryAsync(speechPredictionRequest, cancellationToken).ConfigureAwait(false);
+            var textScore = responseJson.Value<double>("Confidence");
+            return new SpeechPredictionResponse(predictionResponse, textScore);
         }
 
         public void Dispose()

--- a/src/NLU.DevOps.LuisV3/SpeechPredictionResponse.cs
+++ b/src/NLU.DevOps.LuisV3/SpeechPredictionResponse.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.Luis
+{
+    using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.Models;
+
+    /// <summary>
+    /// LUIS response including speech confidence score.
+    /// </summary>
+    public class SpeechPredictionResponse
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpeechPredictionResponse"/> class.
+        /// </summary>
+        /// <param name="predictionResponse">LUIS prediction response.</param>
+        /// <param name="textScore">Text score.</param>
+        public SpeechPredictionResponse(PredictionResponse predictionResponse, double textScore)
+        {
+            this.PredictionResponse = predictionResponse;
+            this.TextScore = textScore;
+        }
+
+        /// <summary>
+        /// Gets the LUIS prediction response.
+        /// </summary>
+        public PredictionResponse PredictionResponse { get; }
+
+        /// <summary>
+        /// Gets the text score.
+        /// </summary>
+        public double TextScore { get; }
+    }
+}

--- a/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
@@ -507,6 +507,74 @@ namespace NLU.DevOps.ModelPerformance.Tests
             compareResults.Statistics.ByEntityType[actualEntityType].FalseNegative.Should().Be(0);
         }
 
+        [Test]
+        public static void GetNLUCompareResultsDefaultScores()
+        {
+            var entityType = Guid.NewGuid().ToString();
+            var matchText = Guid.NewGuid().ToString();
+            var expectedEntity = new[] { new Entity(entityType, null, null, matchText, 0) };
+            var actualEntity = new[] { new Entity(entityType, null, null, matchText, 0) };
+            var expectedUtterance = new LabeledUtterance(null, null, expectedEntity);
+            var actualUtterance = new LabeledUtterance(null, null, actualEntity);
+            var compareResults = TestCaseSource.GetNLUCompareResults(
+                new[] { expectedUtterance },
+                new[] { actualUtterance });
+            compareResults.TestCases.Count.Should().Be(3);
+            compareResults.TestCases.Select(t => t.Score).Should().AllBeEquivalentTo(0);
+        }
+
+        [Test]
+        public static void GetNLUCompareResultsExtractsIntentScore()
+        {
+            var expectedUtterance = new LabeledUtterance(null, null, null);
+            var actualUtterance = new ScoredLabeledUtterance(null, null, 0.5, 0.1, null);
+            var compareResults = TestCaseSource.GetNLUCompareResults(
+                new[] { expectedUtterance },
+                new[] { actualUtterance });
+            compareResults.TestCases.Count.Should().Be(3);
+            var intentTestCase = compareResults.TestCases.FirstOrDefault(t => t.TargetKind == ComparisonTargetKind.Intent);
+            intentTestCase.Should().NotBeNull();
+            intentTestCase.Score.Should().Be(0.5);
+            var textTestCase = compareResults.TestCases.FirstOrDefault(t => t.TargetKind == ComparisonTargetKind.Text);
+            textTestCase.Should().NotBeNull();
+            textTestCase.Score.Should().Be(0.1);
+        }
+
+        [Test]
+        public static void GetNLUCompareResultsExtractsEntityScore()
+        {
+            var entityType = Guid.NewGuid().ToString();
+            var matchText = Guid.NewGuid().ToString();
+            var expectedEntity = new[] { new Entity(entityType, null, null, matchText, 0) };
+            var actualEntity = new[] { new ScoredEntity(entityType, null, null, matchText, 0, 0.5) };
+            var expectedUtterance = new LabeledUtterance(null, null, expectedEntity);
+            var actualUtterance = new LabeledUtterance(null, null, actualEntity);
+            var compareResults = TestCaseSource.GetNLUCompareResults(
+                new[] { expectedUtterance },
+                new[] { actualUtterance });
+            compareResults.TestCases.Count.Should().Be(3);
+            var testCase = compareResults.TestCases.FirstOrDefault(t => t.TargetKind == ComparisonTargetKind.Entity);
+            testCase.Should().NotBeNull();
+            testCase.Score.Should().Be(0.5);
+        }
+
+        [Test]
+        public static void GetNLUCompareResultsExtractsFalsePositiveEntityScore()
+        {
+            var entityType = Guid.NewGuid().ToString();
+            var matchText = Guid.NewGuid().ToString();
+            var actualEntity = new[] { new ScoredEntity(entityType, null, null, matchText, 0, 0.5) };
+            var expectedUtterance = new LabeledUtterance(null, null, null);
+            var actualUtterance = new LabeledUtterance(null, null, actualEntity);
+            var compareResults = TestCaseSource.GetNLUCompareResults(
+                new[] { expectedUtterance },
+                new[] { actualUtterance });
+            compareResults.TestCases.Count.Should().Be(3);
+            var testCase = compareResults.TestCases.FirstOrDefault(t => t.TargetKind == ComparisonTargetKind.Entity);
+            testCase.Should().NotBeNull();
+            testCase.Score.Should().Be(0.5);
+        }
+
         private static List<Entity> CreateEntityList(string type)
         {
             return new List<Entity> { new Entity(type, "EntityValue", null, "matchedText", 1) };

--- a/src/NLU.DevOps.ModelPerformance/ScoredEntity.cs
+++ b/src/NLU.DevOps.ModelPerformance/ScoredEntity.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.ModelPerformance
+{
+    using Models;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Entity appearing in utterance with confidence score.
+    /// </summary>
+    public class ScoredEntity : Entity
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScoredEntity"/> class.
+        /// </summary>
+        /// <param name="entityType">Entity type name.</param>
+        /// <param name="entityValue">Entity value, generally a canonical form of the entity.</param>
+        /// <param name="entityResolution">Entity resolution, generally additional details about the entity.</param>
+        /// <param name="matchText">Matching text in the utterance.</param>
+        /// <param name="matchIndex">Occurrence index of matching token in the utterance.</param>
+        /// <param name="score">Confidence score for the entity.</param>
+        public ScoredEntity(string entityType, JToken entityValue, JToken entityResolution, string matchText, int matchIndex, double score)
+            : base(entityType, entityValue, entityResolution, matchText, matchIndex)
+        {
+            this.Score = score;
+        }
+
+        /// <summary>
+        /// Gets the confidence score for the entity.
+        /// </summary>
+        public double Score { get; }
+    }
+}

--- a/src/NLU.DevOps.ModelPerformance/ScoredLabeledUtterance.cs
+++ b/src/NLU.DevOps.ModelPerformance/ScoredLabeledUtterance.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-namespace NLU.DevOps.Luis
+namespace NLU.DevOps.ModelPerformance
 {
     using System.Collections.Generic;
+    using System.Linq;
     using Models;
 
     /// <summary>
@@ -19,7 +20,7 @@ namespace NLU.DevOps.Luis
         /// <param name="score">Confidence score for the intent label.</param>
         /// <param name="textScore">Confidence score for speech-to-text.</param>
         /// <param name="entities">Entities referenced in the utterance.</param>
-        public ScoredLabeledUtterance(string text, string intent, double score, double textScore, IReadOnlyList<Entity> entities)
+        public ScoredLabeledUtterance(string text, string intent, double score, double textScore, IReadOnlyList<ScoredEntity> entities)
             : base(text, intent, entities)
         {
             this.Score = score;
@@ -35,5 +36,10 @@ namespace NLU.DevOps.Luis
         /// Gets the confidence score for speech-to-text.
         /// </summary>
         public double TextScore { get; }
+
+        /// <summary>
+        /// Gets the entities referenced in the utterance.
+        /// </summary>
+        public new IReadOnlyList<ScoredEntity> Entities => base.Entities.OfType<ScoredEntity>().ToList();
     }
 }

--- a/src/NLU.DevOps.ModelPerformance/TestCase.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestCase.cs
@@ -19,6 +19,7 @@ namespace NLU.DevOps.ModelPerformance
         /// <param name="targetKind">Comparison target kind.</param>
         /// <param name="expectedUtterance">Expected utterance.</param>
         /// <param name="actualUtterance">Actual utterance.</param>
+        /// <param name="score">Confidence score for test case result.</param>
         /// <param name="group">Test case group name.</param>
         /// <param name="testName">Test name.</param>
         /// <param name="because">Because.</param>
@@ -28,6 +29,7 @@ namespace NLU.DevOps.ModelPerformance
             ComparisonTargetKind targetKind,
             LabeledUtterance expectedUtterance,
             LabeledUtterance actualUtterance,
+            double score,
             string group,
             string testName,
             string because,
@@ -37,6 +39,7 @@ namespace NLU.DevOps.ModelPerformance
             this.TargetKind = targetKind;
             this.ExpectedUtterance = expectedUtterance;
             this.ActualUtterance = actualUtterance;
+            this.Score = score;
             this.Group = group;
             this.TestName = testName;
             this.Because = because;
@@ -72,6 +75,11 @@ namespace NLU.DevOps.ModelPerformance
         /// Gets the actual utterance.
         /// </summary>
         public LabeledUtterance ActualUtterance { get; }
+
+        /// <summary>
+        /// Gets the confidence score.
+        /// </summary>
+        public double Score { get; }
 
         /// <summary>
         /// Gets the justification.


### PR DESCRIPTION
Previously, NLU.DevOps.ModelPerformance parsed utterance JSON into a LabeledUtterance model, which loses any additional context (e.g., the "score" property from LUIS). This change ensures that the utterance JSON is passed through to the test case as is, so when serialized, it includes extra properties not in the LabeledUtterance model. The result is that we can pass through the LUIS score to the metadata output in the `compare` command.