### PR TITLE
Makes text comparison optional for compare command

### DIFF
--- a/pipelines/nlu.yml
+++ b/pipelines/nlu.yml
@@ -119,6 +119,7 @@ steps:
       --expected models/tests.speech.json
       --actual $(Agent.TempDirectory)/speech/results.json
       --output-folder $(Build.ArtifactStagingDirectory)/speech
+      --text
 
 - task: DotNetCoreCLI@2
   displayName: Uninstall dotnet-nlu

--- a/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
@@ -4,6 +4,7 @@
 namespace NLU.DevOps.CommandLine.Compare
 {
     using System.Collections.Generic;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using ModelPerformance;
@@ -21,6 +22,7 @@ namespace NLU.DevOps.CommandLine.Compare
             var parameters = CreateParameters(
                 (ConfigurationConstants.ExpectedUtterancesPathKey, options.ExpectedUtterancesPath),
                 (ConfigurationConstants.ActualUtterancesPathKey, options.ActualUtterancesPath),
+                (ConfigurationConstants.CompareTextKey, options.CompareText.ToString(CultureInfo.InvariantCulture)),
                 (ConfigurationConstants.TestLabelKey, options.TestLabel));
 
             var arguments = new List<string> { $"-p:{parameters}" };
@@ -33,7 +35,7 @@ namespace NLU.DevOps.CommandLine.Compare
             {
                 var expectedUtterances = Read<List<LabeledUtterance>>(options.ExpectedUtterancesPath);
                 var actualUtterances = Read<List<ScoredLabeledUtterance>>(options.ExpectedUtterancesPath);
-                var compareResults = TestCaseSource.GetNLUCompareResults(expectedUtterances, actualUtterances);
+                var compareResults = TestCaseSource.GetNLUCompareResults(expectedUtterances, actualUtterances, options.CompareText);
                 var metadataPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestMetadataFileName) : TestMetadataFileName;
                 var statisticsPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestStatisticsFileName) : TestStatisticsFileName;
                 Write(metadataPath, compareResults.TestCases);

--- a/src/NLU.DevOps.CommandLine/Compare/CompareOptions.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareOptions.cs
@@ -20,6 +20,9 @@ namespace NLU.DevOps.CommandLine.Compare
         [Option('m', "metadata", HelpText = "Return test case metadata as opposed to NUnit test results.", Required = false)]
         public bool Metadata { get; set; }
 
+        [Option('t', "text", HelpText = "Run text comparison test cases.", Required = false)]
+        public bool CompareText { get; set; }
+
         [Option('o', "output-folder", HelpText = "Output path for test results.", Required = false)]
         public string OutputFolder { get; set; }
     }

--- a/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
@@ -324,7 +324,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var actualUtterance = new LabeledUtterance(actual, null, null);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
-                new[] { actualUtterance });
+                new[] { actualUtterance },
+                true);
             compareResults.Statistics.Text.TruePositive.Should().Be(truePositive);
             compareResults.Statistics.Text.TrueNegative.Should().Be(trueNegative);
             compareResults.Statistics.Text.FalsePositive.Should().Be(falsePositive);
@@ -353,7 +354,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var actualUtterance = new LabeledUtterance(null, actual, null);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
-                new[] { actualUtterance });
+                new[] { actualUtterance },
+                false);
             compareResults.Statistics.Intent.TruePositive.Should().Be(truePositive);
             compareResults.Statistics.Intent.TrueNegative.Should().Be(trueNegative);
             compareResults.Statistics.Intent.FalsePositive.Should().Be(falsePositive);
@@ -390,7 +392,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var actualUtterance = new LabeledUtterance(null, null, actualEntity);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
-                new[] { actualUtterance });
+                new[] { actualUtterance },
+                false);
             compareResults.Statistics.Entity.TruePositive.Should().Be(truePositive);
             compareResults.Statistics.Entity.TrueNegative.Should().Be(trueNegative);
             compareResults.Statistics.Entity.FalsePositive.Should().Be(falsePositive);
@@ -428,7 +431,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var actualUtterance = new LabeledUtterance(null, null, actualEntity);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
-                new[] { actualUtterance });
+                new[] { actualUtterance },
+                false);
             compareResults.Statistics.EntityValue.TruePositive.Should().Be(truePositive);
             compareResults.Statistics.EntityValue.TrueNegative.Should().Be(trueNegative);
             compareResults.Statistics.EntityValue.FalsePositive.Should().Be(falsePositive);
@@ -466,7 +470,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var actualUtterance = new LabeledUtterance(null, null, actualEntity);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
-                new[] { actualUtterance });
+                new[] { actualUtterance },
+                false);
             compareResults.Statistics.EntityResolution.TruePositive.Should().Be(truePositive);
             compareResults.Statistics.EntityResolution.TrueNegative.Should().Be(trueNegative);
             compareResults.Statistics.EntityResolution.FalsePositive.Should().Be(falsePositive);
@@ -492,7 +497,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var actualUtterance = new LabeledUtterance(null, null, actualEntity);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
-                new[] { actualUtterance });
+                new[] { actualUtterance },
+                false);
             compareResults.Statistics.Entity.TruePositive.Should().Be(0);
             compareResults.Statistics.Entity.TrueNegative.Should().Be(0);
             compareResults.Statistics.Entity.FalsePositive.Should().Be(1);
@@ -518,20 +524,20 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var actualUtterance = new LabeledUtterance(null, null, actualEntity);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
-                new[] { actualUtterance });
-            compareResults.TestCases.Count.Should().Be(3);
+                new[] { actualUtterance },
+                false);
             compareResults.TestCases.Select(t => t.Score).Should().AllBeEquivalentTo(0);
         }
 
         [Test]
-        public static void GetNLUCompareResultsExtractsIntentScore()
+        public static void GetNLUCompareResultsExtractsIntentAndTextScore()
         {
             var expectedUtterance = new LabeledUtterance(null, null, null);
             var actualUtterance = new ScoredLabeledUtterance(null, null, 0.5, 0.1, null);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
-                new[] { actualUtterance });
-            compareResults.TestCases.Count.Should().Be(3);
+                new[] { actualUtterance },
+                true);
             var intentTestCase = compareResults.TestCases.FirstOrDefault(t => t.TargetKind == ComparisonTargetKind.Intent);
             intentTestCase.Should().NotBeNull();
             intentTestCase.Score.Should().Be(0.5);
@@ -551,8 +557,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var actualUtterance = new LabeledUtterance(null, null, actualEntity);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
-                new[] { actualUtterance });
-            compareResults.TestCases.Count.Should().Be(3);
+                new[] { actualUtterance },
+                false);
             var testCase = compareResults.TestCases.FirstOrDefault(t => t.TargetKind == ComparisonTargetKind.Entity);
             testCase.Should().NotBeNull();
             testCase.Score.Should().Be(0.5);
@@ -568,8 +574,8 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var actualUtterance = new LabeledUtterance(null, null, actualEntity);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
-                new[] { actualUtterance });
-            compareResults.TestCases.Count.Should().Be(3);
+                new[] { actualUtterance },
+                false);
             var testCase = compareResults.TestCases.FirstOrDefault(t => t.TargetKind == ComparisonTargetKind.Entity);
             testCase.Should().NotBeNull();
             testCase.Score.Should().Be(0.5);

--- a/src/NLU.DevOps.ModelPerformance/ConfigurationConstants.cs
+++ b/src/NLU.DevOps.ModelPerformance/ConfigurationConstants.cs
@@ -19,6 +19,11 @@ namespace NLU.DevOps.ModelPerformance
         public const string ActualUtterancesPathKey = "actual";
 
         /// <summary>
+        /// A Boolean value that signals whether to generate text comparison tests.
+        /// </summary>
+        public const string CompareTextKey = "compareText";
+
+        /// <summary>
         /// The test label key.
         /// </summary>
         public const string TestLabelKey = "testLabel";


### PR DESCRIPTION
When testing from text utterances, there is no reason to generate test cases for text comparison. This change adds an optional flag to signal that text comparison tests should be run.