### PR TITLE
Fixes minor bug for ScoredLabeledUtterance when entities null

### DIFF
--- a/src/NLU.DevOps.ModelPerformance/ScoredLabeledUtterance.cs
+++ b/src/NLU.DevOps.ModelPerformance/ScoredLabeledUtterance.cs
@@ -40,6 +40,6 @@ namespace NLU.DevOps.ModelPerformance
         /// <summary>
         /// Gets the entities referenced in the utterance.
         /// </summary>
-        public new IReadOnlyList<ScoredEntity> Entities => base.Entities.OfType<ScoredEntity>().ToList();
+        public new IReadOnlyList<ScoredEntity> Entities => base.Entities?.OfType<ScoredEntity>().ToList();
     }
 }


### PR DESCRIPTION
Uses null propagation on call to cast entities into scored entities.