### PR TITLE
Use the correct path for actual utterances

### DIFF
--- a/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
@@ -34,7 +34,7 @@ namespace NLU.DevOps.CommandLine.Compare
             if (options.Metadata)
             {
                 var expectedUtterances = Read<List<LabeledUtterance>>(options.ExpectedUtterancesPath);
-                var actualUtterances = Read<List<ScoredLabeledUtterance>>(options.ExpectedUtterancesPath);
+                var actualUtterances = Read<List<ScoredLabeledUtterance>>(options.ActualUtterancesPath);
                 var compareResults = TestCaseSource.GetNLUCompareResults(expectedUtterances, actualUtterances, options.CompareText);
                 var metadataPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestMetadataFileName) : TestMetadataFileName;
                 var statisticsPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestStatisticsFileName) : TestStatisticsFileName;


### PR DESCRIPTION
Fixes bug where expected utterances path was used for both expected and actual utterances.