### PR TITLE
Fixes issue with ServiceResolver from .NET Core tools folder

### DIFF
--- a/src/NLU.DevOps.CommandLine/ServiceResolver.cs
+++ b/src/NLU.DevOps.CommandLine/ServiceResolver.cs
@@ -23,10 +23,9 @@ namespace NLU.DevOps.CommandLine
                     return defaultSearchPath;
                 }
 
-                var paths = new string[9];
+                var paths = new string[8];
                 paths[0] = AppDomain.CurrentDomain.BaseDirectory;
-                Array.Fill(paths, "..", 1, paths.Length - 2);
-                paths[paths.Length - 1] = assemblyName;
+                Array.Fill(paths, "..", 1, paths.Length - 1);
                 var searchRoot = Path.GetFullPath(Path.Combine(paths));
                 if (!Directory.Exists(searchRoot))
                 {


### PR DESCRIPTION
Identifying the assembly from the .NET Core tools folder was not working properly. The search path needed to be updates to search from the root directory where `dotnet-nlu` was installed.