### PR TITLE
Fixes issue with ServiceResolver assembly search

### DIFF
--- a/src/NLU.DevOps.CommandLine/ServiceResolver.cs
+++ b/src/NLU.DevOps.CommandLine/ServiceResolver.cs
@@ -32,7 +32,14 @@ namespace NLU.DevOps.CommandLine
                     return null;
                 }
 
-                return Directory.GetFiles(searchRoot, assemblyName, SearchOption.AllDirectories).FirstOrDefault();
+                try
+                {
+                    return Directory.GetFiles(searchRoot, assemblyName, SearchOption.AllDirectories).FirstOrDefault();
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    return null;
+                }
             }
 
             var assemblyPath = options.IncludePath ?? getAssemblyPath();


### PR DESCRIPTION
The assembly search, if not run from the .NET Core tools directory, may result in UnauthorizedAccessException. For now, this change swallows the UnauthorizedAccessException and assumes that the assembly will not be resolvable in this case.