### PR TITLE
Fixes local prepend PATH for Windows

### DIFF
--- a/extensions/common/nlu-devops-common/package.json
+++ b/extensions/common/nlu-devops-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nlu-devops-common",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "dependencies": {
         "azure-pipelines-task-lib": "^2.8.0"
     }

--- a/extensions/common/nlu-devops-common/utilities/index.ts
+++ b/extensions/common/nlu-devops-common/utilities/index.ts
@@ -1,6 +1,7 @@
 import * as tl from "azure-pipelines-task-lib/task";
 import * as tr from "azure-pipelines-task-lib/toolrunner";
 import * as path from "path";
+import * as os from "os";
 
 export async function getNLUToolRunner(): Promise<tr.ToolRunner> {
     const dotnetPath = tl.which("dotnet", false);
@@ -80,7 +81,8 @@ export async function getNLUToolRunner(): Promise<tr.ToolRunner> {
             throw new Error("Failed to install NLU.DevOps.");
         }
 
-        process.env.PATH = `${toolPath}:${process.env.PATH}`;
+        const pathDelimiter = os.platform() === "win32" ? ";" : ":";
+        process.env.PATH = `${toolPath}${pathDelimiter}a${process.env.PATH}`;
         tl.prependPath(toolPath);
     }
 

--- a/extensions/tasks/NLUCleanV0/package.json
+++ b/extensions/tasks/NLUCleanV0/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "azure-pipelines-task-lib": "^2.8.0",
-    "nlu-devops-common": "file:../../nlu-devops-common-0.1.3.tgz"
+    "nlu-devops-common": "file:../../nlu-devops-common-0.1.4.tgz"
   }
 }

--- a/extensions/tasks/NLUCleanV0/task.json
+++ b/extensions/tasks/NLUCleanV0/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 3
+        "Patch": 4
     },
     "demands": [],
     "minimumAgentVersion": "2.102.0",

--- a/extensions/tasks/NLUTestV0/package.json
+++ b/extensions/tasks/NLUTestV0/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "azure-pipelines-task-lib": "^2.8.0",
-    "nlu-devops-common": "file:../../nlu-devops-common-0.1.3.tgz"
+    "nlu-devops-common": "file:../../nlu-devops-common-0.1.4.tgz"
   }
 }

--- a/extensions/tasks/NLUTestV0/task.json
+++ b/extensions/tasks/NLUTestV0/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 3
+        "Patch": 4
     },
     "demands": [],
     "minimumAgentVersion": "2.102.0",

--- a/extensions/tasks/NLUTrainV0/package.json
+++ b/extensions/tasks/NLUTrainV0/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "azure-pipelines-task-lib": "^2.8.0",
-    "nlu-devops-common": "file:../../nlu-devops-common-0.1.3.tgz"
+    "nlu-devops-common": "file:../../nlu-devops-common-0.1.4.tgz"
   }
 }

--- a/extensions/tasks/NLUTrainV0/task.json
+++ b/extensions/tasks/NLUTrainV0/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 3
+        "Patch": 4
     },
     "demands": [],
     "minimumAgentVersion": "2.102.0",

--- a/extensions/vss-extension.json
+++ b/extensions/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "nlu-devops",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "name": "NLU.DevOps",
     "description": "A collection of tasks and results tabs for NLU.DevOps",
     "publisher": "NLUDevOps",


### PR DESCRIPTION
Rather than using `:`, when `os.platform()` is `win32`, we should use `;`.