### PR TITLE
Simplify entity model by removing resolution

### DIFF
--- a/src/NLU.DevOps.Core.Tests/LabeledUtteranceConverterTests.cs
+++ b/src/NLU.DevOps.Core.Tests/LabeledUtteranceConverterTests.cs
@@ -46,7 +46,7 @@ namespace NLU.DevOps.Core.Tests
             var entityType = Guid.NewGuid().ToString();
             var matchText = Guid.NewGuid().ToString();
             var matchIndex = 42;
-            var expected = new Entity(entityType, null, null, matchText, matchIndex);
+            var expected = new Entity(entityType, null, matchText, matchIndex);
             var expectedUtterance = new LabeledUtterance(null, null, new[] { expected });
             var serializer = CreateSerializer();
             var json = JObject.FromObject(expectedUtterance, serializer);
@@ -59,7 +59,6 @@ namespace NLU.DevOps.Core.Tests
             actual.MatchText.Should().Be(expected.MatchText);
             actual.MatchIndex.Should().Be(expected.MatchIndex);
             actual.EntityValue.Should().BeNull();
-            actual.EntityResolution.Should().BeNull();
         }
 
         [Test]
@@ -208,7 +207,7 @@ namespace NLU.DevOps.Core.Tests
         private class DerivedEntity : Entity
         {
             public DerivedEntity(string entityType, string matchText, int matchIndex, double score)
-                : base(entityType, null, null, matchText, matchIndex)
+                : base(entityType, null, matchText, matchIndex)
             {
                 this.Score = score;
             }

--- a/src/NLU.DevOps.Dialogflow/DialogflowNLUTestClient.cs
+++ b/src/NLU.DevOps.Dialogflow/DialogflowNLUTestClient.cs
@@ -134,7 +134,7 @@ namespace NLU.DevOps.Dialogflow
                 return null;
             }
 
-            return new Entity(pair.Key, jsonValue, null, null, 0);
+            return new Entity(pair.Key, jsonValue, null, 0);
         }
 
         private async Task<SessionsClient> GetSessionClientAsync(CancellationToken cancellationToken)

--- a/src/NLU.DevOps.Lex.Tests/LexNLUTestClientTests.cs
+++ b/src/NLU.DevOps.Lex.Tests/LexNLUTestClientTests.cs
@@ -101,7 +101,6 @@ namespace NLU.DevOps.Lex.Tests
                     result.Entities.Count.Should().Be(1);
                     result.Entities[0].EntityType.Should().Be(entityType);
                     result.Entities[0].EntityValue.Value<string>().Should().BeEquivalentTo(entityValue);
-                    result.Entities[0].EntityResolution.Should().BeNull();
                 }
             }
         }
@@ -149,7 +148,6 @@ namespace NLU.DevOps.Lex.Tests
                 var response = await lex.TestAsync(text).ConfigureAwait(false);
                 response.Entities[0].EntityType.Should().Be(entityType);
                 response.Entities[0].EntityValue.Value<string>().Should().BeEquivalentTo(entityValue);
-                response.Entities[0].EntityResolution.Should().BeNull();
             }
         }
 

--- a/src/NLU.DevOps.Lex.Tests/LexNLUTrainClientTests.cs
+++ b/src/NLU.DevOps.Lex.Tests/LexNLUTrainClientTests.cs
@@ -52,7 +52,7 @@ namespace NLU.DevOps.Lex.Tests
             var mockClient = CreateLexTrainClientMock();
             using (var lex = new LexNLUTrainClient(string.Empty, string.Empty, new LexSettings(), mockClient.Object))
             {
-                var entity = new Entity(null, null, null, match, 0);
+                var entity = new Entity(null, null, match, 0);
                 var utterance = new LabeledUtterance(text, null, new[] { entity });
                 var invalidEntityMatch = new Func<Task>(() => lex.TrainAsync(new[] { utterance }));
                 invalidEntityMatch.Should().Throw<InvalidOperationException>();
@@ -79,7 +79,7 @@ namespace NLU.DevOps.Lex.Tests
             var lexSettings = new LexSettings(new JArray { slot });
             using (var lex = new LexNLUTrainClient(botName, string.Empty, lexSettings, mockClient.Object))
             {
-                var entity = new Entity(entityTypeName, "Earth", null, "world", 0);
+                var entity = new Entity(entityTypeName, "Earth", "world", 0);
                 var utterance = new LabeledUtterance(text, intent, new[] { entity });
 
                 await lex.TrainAsync(new[] { utterance }).ConfigureAwait(false);
@@ -131,7 +131,7 @@ namespace NLU.DevOps.Lex.Tests
             var lexSettings = new LexSettings(new JArray { slot });
             using (var lex = new LexNLUTrainClient(string.Empty, string.Empty, lexSettings, mockClient.Object))
             {
-                var entity = new Entity(entityTypeName, null, null, entityMatch, matchIndex);
+                var entity = new Entity(entityTypeName, null, entityMatch, matchIndex);
                 var utterance = new LabeledUtterance(text, intent, new[] { entity });
 
                 await lex.TrainAsync(new[] { utterance }).ConfigureAwait(false);
@@ -437,7 +437,7 @@ namespace NLU.DevOps.Lex.Tests
             using (var lex = new LexNLUTrainClient(string.Empty, string.Empty, lexSettings, mockClient.Object))
             {
                 var text = Guid.NewGuid().ToString();
-                var entity = new Entity(entityTypeName, null, null, text, 0);
+                var entity = new Entity(entityTypeName, null, text, 0);
                 var utterance = new LabeledUtterance(text, intentName, new[] { entity });
                 await lex.TrainAsync(new[] { utterance }).ConfigureAwait(false);
 

--- a/src/NLU.DevOps.Lex/LexNLUTestClient.cs
+++ b/src/NLU.DevOps.Lex/LexNLUTestClient.cs
@@ -91,7 +91,7 @@ namespace NLU.DevOps.Lex
             var postTextResponse = await this.LexClient.PostTextAsync(postTextRequest, cancellationToken).ConfigureAwait(false);
             var entities = postTextResponse.Slots?
                 .Where(slot => slot.Value != null)
-                .Select(slot => new Entity(slot.Key, slot.Value, null, null, 0))
+                .Select(slot => new Entity(slot.Key, slot.Value, null, 0))
                 .ToArray();
 
             return new LabeledUtterance(
@@ -123,7 +123,7 @@ namespace NLU.DevOps.Lex
                 var postContentResponse = await this.LexClient.PostContentAsync(postContentRequest, cancellationToken).ConfigureAwait(false);
                 var slots = postContentResponse.Slots != null
                     ? JsonConvert.DeserializeObject<Dictionary<string, string>>(postContentResponse.Slots)
-                        .Select(slot => new Entity(slot.Key, slot.Value, null, null, 0))
+                        .Select(slot => new Entity(slot.Key, slot.Value, null, 0))
                         .ToArray()
                     : null;
 

--- a/src/NLU.DevOps.Luis.Shared/ScoredEntity.cs
+++ b/src/NLU.DevOps.Luis.Shared/ScoredEntity.cs
@@ -16,12 +16,11 @@ namespace NLU.DevOps.Luis
         /// </summary>
         /// <param name="entityType">Entity type name.</param>
         /// <param name="entityValue">Entity value, generally a canonical form of the entity.</param>
-        /// <param name="entityResolution">Entity resolution, generally additional details about the entity.</param>
         /// <param name="matchText">Matching text in the utterance.</param>
         /// <param name="matchIndex">Occurrence index of matching token in the utterance.</param>
         /// <param name="score">Confidence score for the entity.</param>
-        public ScoredEntity(string entityType, JToken entityValue, JToken entityResolution, string matchText, int matchIndex, double score)
-            : base(entityType, entityValue, entityResolution, matchText, matchIndex)
+        public ScoredEntity(string entityType, JToken entityValue, string matchText, int matchIndex, double score)
+            : base(entityType, entityValue, matchText, matchIndex)
         {
             this.Score = score;
         }

--- a/src/NLU.DevOps.Luis.Tests.Shared/LuisNLUTrainClientTests.cs
+++ b/src/NLU.DevOps.Luis.Tests.Shared/LuisNLUTrainClientTests.cs
@@ -127,11 +127,11 @@ namespace NLU.DevOps.Luis.Tests
                     new Models.LabeledUtterance(
                         "Book me a flight.",
                         "BookFlight",
-                        new Entity[] { new Entity("Name", null, null, "me", 0) }),
+                        new[] { new Entity("Name", null, "me", 0) }),
                     new Models.LabeledUtterance(
                         "Cancel my flight.",
                         "CancelFlight",
-                        new Entity[] { new Entity("Subject", null, null, "flight", 0) })
+                        new[] { new Entity("Subject", null, "flight", 0) })
                 };
 
                 await luis.TrainAsync(utterances).ConfigureAwait(false);
@@ -315,8 +315,8 @@ namespace NLU.DevOps.Luis.Tests
             builder.LuisSettings = new LuisSettings(prebuiltEntityTypes);
             using (var luis = builder.Build())
             {
-                var entity1 = new Entity(entityTypeName1, null, null, text, 0);
-                var entity2 = new Entity(entityTypeName2, null, null, text, 0);
+                var entity1 = new Entity(entityTypeName1, null, text, 0);
+                var entity2 = new Entity(entityTypeName2, null, text, 0);
                 var utterance = new Models.LabeledUtterance(text, string.Empty, new[] { entity1, entity2 });
                 await luis.TrainAsync(new[] { utterance }).ConfigureAwait(false);
 

--- a/src/NLU.DevOps.Luis.Tests/LuisNLUTestClientTests.cs
+++ b/src/NLU.DevOps.Luis.Tests/LuisNLUTestClientTests.cs
@@ -69,7 +69,6 @@ namespace NLU.DevOps.Luis.Tests
                 result.Entities.Count.Should().Be(1);
                 result.Entities[0].EntityType.Should().Be("type");
                 result.Entities[0].EntityValue.Should().BeNull();
-                result.Entities[0].EntityResolution.Should().BeNull();
                 result.Entities[0].MatchText.Should().Be("the");
                 result.Entities[0].MatchIndex.Should().Be(1);
             }
@@ -133,12 +132,9 @@ namespace NLU.DevOps.Luis.Tests
             {
                 var result = await luis.TestAsync(test).ConfigureAwait(false);
                 result.Entities.Count.Should().Be(3);
-                result.Entities[0].EntityValue.Should().BeEquivalentTo(new JValue("THE"));
-                result.Entities[0].EntityResolution.Should().BeEquivalentTo(valueResolution);
-                result.Entities[1].EntityValue.Should().BeEquivalentTo(new JValue("Fox"));
-                result.Entities[1].EntityResolution.Should().BeEquivalentTo(valuesStringResolution);
-                result.Entities[2].EntityValue.Should().BeEquivalentTo(new JValue("2018-11-16"));
-                result.Entities[2].EntityResolution.Should().BeEquivalentTo(valuesValueResolution);
+                result.Entities[0].EntityValue.Should().BeEquivalentTo(valueResolution["value"]);
+                result.Entities[1].EntityValue.Should().BeEquivalentTo(valuesStringResolution["values"]);
+                result.Entities[2].EntityValue.Should().BeEquivalentTo(valuesValueResolution["values"]);
             }
         }
 
@@ -255,7 +251,6 @@ namespace NLU.DevOps.Luis.Tests
                 result.Entities.Count.Should().Be(1);
                 result.Entities[0].EntityType.Should().Be("type");
                 result.Entities[0].EntityValue.Should().BeNull();
-                result.Entities[0].EntityResolution.Should().BeNull();
                 result.Entities[0].MatchText.Should().Be("the");
                 result.Entities[0].MatchIndex.Should().Be(1);
             }

--- a/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
@@ -74,11 +74,13 @@ namespace NLU.DevOps.Luis
                 return value;
             }
 
-            // TODO: should we return multiple values?
-            var resolvedValue = resolution["values"][0];
-            return resolvedValue is JObject resolvedObject
-                ? resolvedObject["value"]
-                : resolvedValue;
+            var values = resolution["values"];
+            if (values != null)
+            {
+                return values;
+            }
+
+            return resolution;
         }
 
         private LabeledUtterance LuisResultToLabeledUtterance(SpeechLuisResult speechLuisResult)
@@ -100,13 +102,11 @@ namespace NLU.DevOps.Luis
                 }
 
                 var entityValue = default(JToken);
-                var entityResolution = default(JToken);
                 if (entity.AdditionalProperties != null &&
                     entity.AdditionalProperties.TryGetValue("resolution", out var resolution) &&
                     resolution is JToken resolutionJson)
                 {
                     entityValue = GetEntityValue(resolutionJson);
-                    entityResolution = resolutionJson;
                 }
 
                 var matchText = entity.Entity;
@@ -132,8 +132,8 @@ namespace NLU.DevOps.Luis
                 }
 
                 return entityScore.HasValue
-                    ? new ScoredEntity(entityType, entityValue, entityResolution, matchText, matchIndex, entityScore.Value)
-                    : new Entity(entityType, entityValue, entityResolution, matchText, matchIndex);
+                    ? new ScoredEntity(entityType, entityValue, matchText, matchIndex, entityScore.Value)
+                    : new Entity(entityType, entityValue, matchText, matchIndex);
             }
 
             var intent = speechLuisResult.LuisResult.TopScoringIntent?.Intent;

--- a/src/NLU.DevOps.LuisV3.Tests/LuisNLUTestClientTests.cs
+++ b/src/NLU.DevOps.LuisV3.Tests/LuisNLUTestClientTests.cs
@@ -73,98 +73,8 @@ namespace NLU.DevOps.Luis.Tests
                 result.Entities.Count.Should().Be(1);
                 result.Entities[0].EntityType.Should().Be("type");
                 result.Entities[0].EntityValue.Should().BeEquivalentTo(new JValue("the"));
-                result.Entities[0].EntityResolution.Should().BeNull();
                 result.Entities[0].MatchText.Should().Be("the");
                 result.Entities[0].MatchIndex.Should().Be(1);
-            }
-        }
-
-        [Test]
-        public static async Task TestModelWithEntityResolution()
-        {
-            var test = "the quick brown fox jumped over the lazy dog";
-            var resolution = new JObject
-            {
-                { "value", "Fox" },
-            };
-
-            var entityValues = new JToken[]
-            {
-                "2018-11-16",
-                new JArray { new JArray { "Fox" } },
-                new JArray { new JArray { "foo", "bar" } },
-                new JArray { new JObject() },
-            };
-
-            var builder = new LuisNLUTestClientBuilder();
-            builder.LuisTestClientMock
-                .Setup(luis => luis.QueryAsync(
-                    It.Is<PredictionRequest>(query => query.Query == test),
-                    It.IsAny<CancellationToken>()))
-                .Returns(() => Task.FromResult(new PredictionResponse
-                {
-                    Query = "the quick brown fox jumped over the lazy dog today",
-                    Prediction = new Prediction
-                    {
-                        Entities = new Dictionary<string, object>
-                        {
-                            {
-                                "type",
-                                new JArray(entityValues)
-                            },
-                            {
-                                "$instance",
-                                new JObject
-                                {
-                                    {
-                                        "type",
-                                        new JArray
-                                        {
-                                            new JObject
-                                            {
-                                                { "startIndex", 45 },
-                                                { "length", 5 },
-                                                { "resolution", resolution.DeepClone() },
-                                            },
-                                            new JObject
-                                            {
-                                                { "startIndex", 10 },
-                                                { "length", 9 },
-                                            },
-                                            new JObject
-                                            {
-                                                { "startIndex", 0 },
-                                                { "length", 3 },
-                                            },
-                                            new JObject
-                                            {
-                                                { "startIndex", 4 },
-                                                { "length", 5 },
-                                            },
-                                        }
-                                    },
-                                }
-                            },
-                        }
-                    },
-                }));
-
-            using (var luis = builder.Build())
-            {
-                var result = await luis.TestAsync(test).ConfigureAwait(false);
-                result.Entities.Count.Should().Be(4);
-                result.Entities[0].MatchText.Should().Be("today");
-                result.Entities[0].EntityValue.Should().BeEquivalentTo(entityValues[0]);
-                result.Entities[0].EntityResolution.Should().BeEquivalentTo(resolution);
-                result.Entities[1].MatchText.Should().Be("brown fox");
-                result.Entities[1].EntityValue.Should().BeEquivalentTo(entityValues[1]);
-                result.Entities[1].EntityResolution.Should().BeNull();
-                result.Entities[2].MatchText.Should().Be("the");
-                result.Entities[2].EntityValue.Should().BeEquivalentTo(entityValues[2]);
-                result.Entities[2].EntityResolution.Should().BeNull();
-                result.Entities[3].MatchText.Should().Be("quick");
-                result.Entities[3].EntityValue.Should().BeEquivalentTo(entityValues[3]);
-                result.Entities[3].EntityResolution.Should().BeNull();
             }
         }
 
@@ -291,7 +201,6 @@ namespace NLU.DevOps.Luis.Tests
                 result.Entities.Count.Should().Be(1);
                 result.Entities[0].EntityType.Should().Be("type");
                 result.Entities[0].EntityValue.Should().BeEquivalentTo(new JValue("the"));
-                result.Entities[0].EntityResolution.Should().BeNull();
                 result.Entities[0].MatchText.Should().Be("the");
                 result.Entities[0].MatchIndex.Should().Be(1);
             }

--- a/src/NLU.DevOps.LuisV3/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.LuisV3/LuisNLUTestClient.cs
@@ -108,10 +108,9 @@ namespace NLU.DevOps.Luis
                     modifiedEntityType = mappedEntityType;
                 }
 
-                var entityResolution = entityMetadata["resolution"];
                 return score.HasValue
-                    ? new ScoredEntity(modifiedEntityType, entityValue, entityResolution, matchText, matchIndex, score.Value)
-                    : new Entity(modifiedEntityType, entityValue, entityResolution, matchText, matchIndex);
+                    ? new ScoredEntity(modifiedEntityType, entityValue, matchText, matchIndex, score.Value)
+                    : new Entity(modifiedEntityType, entityValue, matchText, matchIndex);
             }
 
             var instanceMetadata = default(JObject);

--- a/src/NLU.DevOps.ModelPerformance.Tests/models/actualUtterances.json
+++ b/src/NLU.DevOps.ModelPerformance.Tests/models/actualUtterances.json
@@ -26,12 +26,7 @@
         "entityType": "City",
         "entityValue": "New York City",
         "matchText": null,
-        "matchIndex": 0,
-        "entityResolution": {
-          "location": "NYC",
-          "latitude": 40.7128,
-          "longitude": -74.0060
-        }
+        "matchIndex": 0
       }
     ],
     "intent": "BookFlight",

--- a/src/NLU.DevOps.ModelPerformance.Tests/models/expectedUtterances.json
+++ b/src/NLU.DevOps.ModelPerformance.Tests/models/expectedUtterances.json
@@ -26,10 +26,7 @@
         "entityType": "City",
         "entityValue": "New York City",
         "matchText": "the big apple",
-        "matchIndex": 0,
-        "entityResolution": {
-          "location": "NYC"
-        }
+        "matchIndex": 0
       }
     ],
     "intent": "BookFlight",

--- a/src/NLU.DevOps.ModelPerformance/ComparisonTargetKind.cs
+++ b/src/NLU.DevOps.ModelPerformance/ComparisonTargetKind.cs
@@ -31,11 +31,6 @@ namespace NLU.DevOps.ModelPerformance
         /// <summary>
         /// Entity value.
         /// </summary>
-        EntityValue,
-
-        /// <summary>
-        /// Entity resolution.
-        /// </summary>
-        EntityResolution
+        EntityValue
     }
 }

--- a/src/NLU.DevOps.ModelPerformance/NLUCompareResults.cs
+++ b/src/NLU.DevOps.ModelPerformance/NLUCompareResults.cs
@@ -63,7 +63,6 @@ namespace NLU.DevOps.ModelPerformance
                 CalculateConfusionMatrix(this.TestCases.Where(testCase => testCase.TargetKind == ComparisonTargetKind.Intent)),
                 CalculateConfusionMatrix(this.TestCases.Where(testCase => testCase.TargetKind == ComparisonTargetKind.Entity)),
                 CalculateConfusionMatrix(this.TestCases.Where(testCase => testCase.TargetKind == ComparisonTargetKind.EntityValue)),
-                CalculateConfusionMatrix(this.TestCases.Where(testCase => testCase.TargetKind == ComparisonTargetKind.EntityResolution)),
                 this.TestCases
                     .Where(testCase => testCase.Group != null)
                     .Where(testCase => testCase.TargetKind == ComparisonTargetKind.Intent)
@@ -77,11 +76,6 @@ namespace NLU.DevOps.ModelPerformance
                 this.TestCases
                     .Where(testCase => testCase.Group != null)
                     .Where(testCase => testCase.TargetKind == ComparisonTargetKind.EntityValue)
-                    .GroupBy(testCase => testCase.Group)
-                    .ToDictionary(group => group.Key, group => CalculateConfusionMatrix(group)),
-                this.TestCases
-                    .Where(testCase => testCase.Group != null)
-                    .Where(testCase => testCase.TargetKind == ComparisonTargetKind.EntityResolution)
                     .GroupBy(testCase => testCase.Group)
                     .ToDictionary(group => group.Key, group => CalculateConfusionMatrix(group)));
         }

--- a/src/NLU.DevOps.ModelPerformance/NLUStatistics.cs
+++ b/src/NLU.DevOps.ModelPerformance/NLUStatistics.cs
@@ -17,31 +17,25 @@ namespace NLU.DevOps.ModelPerformance
         /// <param name="intent">Intent confusion matrix.</param>
         /// <param name="entity">Entity confusion matrix.</param>
         /// <param name="entityValue">Entity value confusion matrix.</param>
-        /// <param name="entityResolution">Entity resolution confusion matrix.</param>
         /// <param name="byIntent">By intent confusion matrix.</param>
         /// <param name="byEntityType">By entity type confusion matrix.</param>
         /// <param name="byEntityValueType">By entity value type confusion matrix.</param>
-        /// <param name="byEntityResolutionType">By entity resolution type confusion matrix.</param>
         public NLUStatistics(
             ConfusionMatrix text,
             ConfusionMatrix intent,
             ConfusionMatrix entity,
             ConfusionMatrix entityValue,
-            ConfusionMatrix entityResolution,
             IReadOnlyDictionary<string, ConfusionMatrix> byIntent,
             IReadOnlyDictionary<string, ConfusionMatrix> byEntityType,
-            IReadOnlyDictionary<string, ConfusionMatrix> byEntityValueType,
-            IReadOnlyDictionary<string, ConfusionMatrix> byEntityResolutionType)
+            IReadOnlyDictionary<string, ConfusionMatrix> byEntityValueType)
         {
             this.Text = text;
             this.Intent = intent;
             this.Entity = entity;
             this.EntityValue = entityValue;
-            this.EntityResolution = entityResolution;
             this.ByIntent = byIntent;
             this.ByEntityType = byEntityType;
             this.ByEntityValueType = byEntityValueType;
-            this.ByEntityResolutionType = byEntityResolutionType;
         }
 
         /// <summary>
@@ -65,11 +59,6 @@ namespace NLU.DevOps.ModelPerformance
         public ConfusionMatrix EntityValue { get; }
 
         /// <summary>
-        /// Gets the entity resolution confusion matrix.
-        /// </summary>
-        public ConfusionMatrix EntityResolution { get; }
-
-        /// <summary>
         /// Gets the intent confusion matrix by intent.
         /// </summary>
         public IReadOnlyDictionary<string, ConfusionMatrix> ByIntent { get; }
@@ -83,10 +72,5 @@ namespace NLU.DevOps.ModelPerformance
         /// Gets the entity value confusion matrix by entity type.
         /// </summary>
         public IReadOnlyDictionary<string, ConfusionMatrix> ByEntityValueType { get; }
-
-        /// <summary>
-        /// Gets the type of the by entity resolution confusion matrix by entity type.
-        /// </summary>
-        public IReadOnlyDictionary<string, ConfusionMatrix> ByEntityResolutionType { get; }
     }
 }

--- a/src/NLU.DevOps.ModelPerformance/ScoredEntity.cs
+++ b/src/NLU.DevOps.ModelPerformance/ScoredEntity.cs
@@ -16,12 +16,11 @@ namespace NLU.DevOps.ModelPerformance
         /// </summary>
         /// <param name="entityType">Entity type name.</param>
         /// <param name="entityValue">Entity value, generally a canonical form of the entity.</param>
-        /// <param name="entityResolution">Entity resolution, generally additional details about the entity.</param>
         /// <param name="matchText">Matching text in the utterance.</param>
         /// <param name="matchIndex">Occurrence index of matching token in the utterance.</param>
         /// <param name="score">Confidence score for the entity.</param>
-        public ScoredEntity(string entityType, JToken entityValue, JToken entityResolution, string matchText, int matchIndex, double score)
-            : base(entityType, entityValue, entityResolution, matchText, matchIndex)
+        public ScoredEntity(string entityType, JToken entityValue, string matchText, int matchIndex, double score)
+            : base(entityType, entityValue, matchText, matchIndex)
         {
             this.Score = score;
         }

--- a/src/NLU.DevOps.ModelPerformance/TestCaseSource.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestCaseSource.cs
@@ -321,35 +321,6 @@ namespace NLU.DevOps.ModelPerformance
                                     "Entity");
                             }
                         }
-
-                        if (entity.EntityResolution != null && entity.EntityResolution.Type != JTokenType.Null)
-                        {
-                            var formattedEntityResolution = entity.EntityResolution.ToString(Formatting.None);
-                            if (!ContainsSubtree(entity.EntityResolution, matchedEntity.EntityResolution))
-                            {
-                                yield return FalseNegative(
-                                    ComparisonTargetKind.EntityResolution,
-                                    expectedUtterance,
-                                    actualUtterance,
-                                    score,
-                                    entity.EntityType,
-                                    new[] { entity.EntityType, formattedEntityResolution, text },
-                                    $"Actual utterance does not have entity resolution matching '{formattedEntityResolution}'.",
-                                    "Entity");
-                            }
-                            else
-                            {
-                                yield return TruePositive(
-                                    ComparisonTargetKind.EntityResolution,
-                                    expectedUtterance,
-                                    actualUtterance,
-                                    score,
-                                    entity.EntityType,
-                                    new[] { entity.EntityType, formattedEntityResolution, text },
-                                    $"Both utterances contain expected resolution '{formattedEntityResolution}'.",
-                                    "Entity");
-                            }
-                        }
                     }
                 }
             }

--- a/src/NLU.DevOps.Models/Entity.cs
+++ b/src/NLU.DevOps.Models/Entity.cs
@@ -15,14 +15,12 @@ namespace NLU.DevOps.Models
         /// </summary>
         /// <param name="entityType">Entity type name.</param>
         /// <param name="entityValue">Entity value, generally a canonical form of the entity.</param>
-        /// <param name="entityResolution">Entity resolution, generally additional details about the entity.</param>
         /// <param name="matchText">Matching text in the utterance.</param>
         /// <param name="matchIndex">Occurrence index of matching token in the utterance.</param>
-        public Entity(string entityType, JToken entityValue, JToken entityResolution, string matchText, int matchIndex)
+        public Entity(string entityType, JToken entityValue, string matchText, int matchIndex)
         {
             this.EntityType = entityType;
             this.EntityValue = entityValue;
-            this.EntityResolution = entityResolution;
             this.MatchText = matchText;
             this.MatchIndex = matchIndex;
         }
@@ -36,12 +34,6 @@ namespace NLU.DevOps.Models
         /// Gets the entity value, generally a canonical form of the entity.
         /// </summary>
         public JToken EntityValue { get; }
-
-        /// <summary>
-        /// Gets the entitiy resolution, generally additional details about the entity.
-        /// </summary>
-        /// <value>The entity resolution.</value>
-        public JToken EntityResolution { get; }
 
         /// <summary>
         /// Gets the matching text in the utterance.


### PR DESCRIPTION
Removes entity resolution from Entity model and all associated usages. The `entityResolution` option for comparison was overly specific to LUIS, and a similar effect can be achieved by putting the putting the `resolution` values as is into the `entityValue` field, rather than trying to extract a singular value.

Note - this is a breaking change for LUIS v2, as we no longer lift the first value from the "values" property in the "resolution" object from the LUIS response.