### PR TITLE
Adds input for 'publishNLUResults'

### DIFF
--- a/pipelines/nlu-extension.yml
+++ b/pipelines/nlu-extension.yml
@@ -46,6 +46,7 @@ steps:
     utterances: models/tests.json
     nupkgPath: $(Build.ArtifactStagingDirectory)
     publishTestResults: true
+    publishNLUResults: true
 
 - task: NLUClean@0
   displayName: Cleanup the NLU service


### PR DESCRIPTION
Sets `publishNLUResults` to simplify testing of NLU confusion matrix visualization testing.