### PR TITLE
Reverts version numbers to 0.1.0

### DIFF
--- a/extensions/tasks/NLUCleanV0/task.json
+++ b/extensions/tasks/NLUCleanV0/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 4
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.102.0",

--- a/extensions/tasks/NLUTestV0/task.json
+++ b/extensions/tasks/NLUTestV0/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 4
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.102.0",

--- a/extensions/tasks/NLUTrainV0/task.json
+++ b/extensions/tasks/NLUTrainV0/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 4
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.102.0",

--- a/extensions/vss-extension.json
+++ b/extensions/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "nlu-devops",
-    "version": "0.1.4",
+    "version": "0.1.0",
     "name": "NLU.DevOps",
     "description": "A collection of tasks and results tabs for NLU.DevOps",
     "publisher": "NLUDevOps",


### PR DESCRIPTION
Since the patch numbers will be controlled by the release pipelines, we can revert the patch numbers back to 0, setting the base version to 0.1.*.