### PR TITLE
Bumps version to 0.4.0

### DIFF
--- a/src/CommonNuget.props
+++ b/src/CommonNuget.props
@@ -8,6 +8,6 @@
     <PackageProjectUrl>https://github.com/Microsoft/NLU.DevOps</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Microsoft/NLU.DevOps.git</RepositoryUrl>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <Version>0.3.7</Version>
+    <Version>0.4.0</Version>
   </PropertyGroup>
 </Project>

--- a/src/NLU.DevOps.Core/NLU.DevOps.Core.csproj
+++ b/src/NLU.DevOps.Core/NLU.DevOps.Core.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CodeAnalysis.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>0.2.0</AssemblyVersion>
+    <AssemblyVersion>0.4.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">

--- a/src/NLU.DevOps.Models/NLU.DevOps.Models.csproj
+++ b/src/NLU.DevOps.Models/NLU.DevOps.Models.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CodeAnalysis.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>0.2.0</AssemblyVersion>
+    <AssemblyVersion>0.4.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">


### PR DESCRIPTION
The next release contains a breaking change for the `Entity` DTO, where we removed the `EntityResolution` property. As such, in addition to bumping the version on `NLU.DevOps.CommandLine`, we are also bumping the version on `NLU.DevOps.Models` and `NLU.DevOps.Core`. Bumps each version to 0.4.0 in preparation for release.