### PR TITLE
Leverage LUIS endpoint key for testing

### DIFF
--- a/pipelines/nlu-extension.yml
+++ b/pipelines/nlu-extension.yml
@@ -31,6 +31,21 @@ steps:
     packagesToPack: src/NLU.DevOps.CommandLine
     configuration: Release
 
+- task: AzurePowerShell@4
+  displayName: Get ARM token for Azure
+  condition: and(succeeded(), ne(variables['nlu.ci'], 'false'))
+  inputs:
+    azureSubscription: $(azureSubscription)
+    azurePowerShellVersion: latestVersion
+    scriptType: inlineScript
+    inline: |
+      $azProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile
+      $currentAzureContext = Get-AzContext
+      $profileClient = New-Object Microsoft.Azure.Commands.ResourceManager.Common.RMProfileClient($azProfile)
+      $token = $profileClient.AcquireAccessToken($currentAzureContext.Tenant.TenantId)
+      $setVariableMessage = "##vso[task.setvariable variable=arm_token]{0}" -f $token.AccessToken 
+      echo $setVariableMessage
+
 - task: NLUTrain@0
   displayName: Train NLU model
   inputs:


### PR DESCRIPTION
To avoid the risk of exhausting the authoring key for CI builds, this change allows us to use the endpoint key for CI builds for testing the NLU.DevOps extension.