### PR TITLE
Adds mock provider implementation for use in samples and CI builds

### DIFF
--- a/src/NLU.DevOps.MockProvider/MockNLUClient.cs
+++ b/src/NLU.DevOps.MockProvider/MockNLUClient.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.MockProvider
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Core;
+    using Models;
+    using Newtonsoft.Json;
+
+    internal class MockNLUClient : DefaultNLUTestClient, INLUTrainClient
+    {
+        public MockNLUClient(string trainedUtterances)
+        {
+            this.Utterances = new List<LabeledUtterance>();
+            if (trainedUtterances != null)
+            {
+                this.Utterances.AddRange(
+                    JsonConvert.DeserializeObject<IEnumerable<LabeledUtterance>>(trainedUtterances));
+            }
+        }
+
+        public string TrainedUtterances => JsonConvert.SerializeObject(this.Utterances);
+
+        private List<LabeledUtterance> Utterances { get; }
+
+        public Task TrainAsync(IEnumerable<LabeledUtterance> utterances, CancellationToken cancellationToken)
+        {
+            this.Utterances.AddRange(utterances);
+            return Task.CompletedTask;
+        }
+
+        public Task CleanupAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        protected override Task<LabeledUtterance> TestAsync(string utterance, CancellationToken cancellationToken)
+        {
+            var matchedUtterance = this.Utterances.FirstOrDefault(u => u.Text == utterance);
+            return Task.FromResult(matchedUtterance ?? new LabeledUtterance(null, null, null));
+        }
+
+        protected override Task<LabeledUtterance> TestSpeechAsync(string speechFile, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+        }
+    }
+}

--- a/src/NLU.DevOps.MockProvider/MockNLUClientFactory.cs
+++ b/src/NLU.DevOps.MockProvider/MockNLUClientFactory.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.MockProvider
+{
+    using System.Composition;
+    using Microsoft.Extensions.Configuration;
+    using Models;
+
+    [Export("mock", typeof(INLUClientFactory))]
+    internal class MockNLUClientFactory : INLUClientFactory
+    {
+        public INLUTrainClient CreateTrainInstance(IConfiguration configuration, string settingsPath)
+        {
+            return new MockNLUClient(configuration["trainedUtterances"]);
+        }
+
+        public INLUTestClient CreateTestInstance(IConfiguration configuration, string settingsPath)
+        {
+            return new MockNLUClient(configuration["trainedUtterances"]);
+        }
+    }
+}

--- a/src/NLU.DevOps.MockProvider/NLU.DevOps.MockProvider.csproj
+++ b/src/NLU.DevOps.MockProvider/NLU.DevOps.MockProvider.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\CommonNuget.props" />
+  <Import Project="..\CodeAnalysis.props" />
+
+  <PropertyGroup>
+    <AssemblyName>dotnet-nlu-mock</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <PackAsTool>true</PackAsTool>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="System.Composition.AttributedModel" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NLU.DevOps.Models\NLU.DevOps.Models.csproj" />
+    <ProjectReference Include="..\NLU.DevOps.Core\NLU.DevOps.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NLU.DevOps.MockProvider/Program.cs
+++ b/src/NLU.DevOps.MockProvider/Program.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.MockProvider
+{
+    using System;
+
+    internal class Program
+    {
+        private static void Main()
+        {
+        }
+    }
+}

--- a/src/NLU.DevOps.sln
+++ b/src/NLU.DevOps.sln
@@ -33,6 +33,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLU.DevOps.Dialogflow", "NL
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLU.DevOps.Dialogflow.Tests", "NLU.DevOps.Dialogflow.Tests\NLU.DevOps.Dialogflow.Tests.csproj", "{54227476-C6BE-4EE2-ADD7-798B0F9103AA}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLU.DevOps.MockProvider", "NLU.DevOps.MockProvider\NLU.DevOps.MockProvider.csproj", "{9B14AEE8-8BC5-455D-BD84-FA32698BCFBA}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLU.DevOps.CommandLine", "NLU.DevOps.CommandLine\NLU.DevOps.CommandLine.csproj", "{ED09E7CE-E721-415A-A0CA-1B928EC4E7A0}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLU.DevOps.CommandLine.Tests", "NLU.DevOps.CommandLine.Tests\NLU.DevOps.CommandLine.Tests.csproj", "{1F5ADDE0-4414-4B49-9810-69B58EED51AF}"
@@ -99,6 +101,10 @@ Global
 		{54227476-C6BE-4EE2-ADD7-798B0F9103AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{54227476-C6BE-4EE2-ADD7-798B0F9103AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{54227476-C6BE-4EE2-ADD7-798B0F9103AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B14AEE8-8BC5-455D-BD84-FA32698BCFBA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B14AEE8-8BC5-455D-BD84-FA32698BCFBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B14AEE8-8BC5-455D-BD84-FA32698BCFBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B14AEE8-8BC5-455D-BD84-FA32698BCFBA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{ED09E7CE-E721-415A-A0CA-1B928EC4E7A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{ED09E7CE-E721-415A-A0CA-1B928EC4E7A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ED09E7CE-E721-415A-A0CA-1B928EC4E7A0}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
This PR adds a mock provider to the repo so we can avoid using LUIS for end-to-end tests running in CI.

Fixes #127