### PR TITLE
Adds infrastructure for passing NLU results to Azure Pipelines tab

### DIFF
--- a/extensions/package.json
+++ b/extensions/package.json
@@ -11,7 +11,8 @@
         "lintFix": "npm run lintCommon -- --fix && npm run lintTasks -- --fix && npm run eclintFix",
         "buildCommon": "npm-recursive-install --rootDir=common && tsc -p common && npm pack common/nlu-devops-common/",
         "buildTasks": "npm-recursive-install --rootDir=tasks && tsc -p tasks",
-        "build": "npm run buildCommon && npm run buildTasks",
+        "buildTabs": "npm-recursive-install --rootDir=tabs",
+        "build": "npm run buildCommon && npm run buildTasks && npm run buildTabs",
         "postbuild": "npm run package",
         "package": "tfx extension create --rev-version --manifest-globs",
         "clean": "rimraf ./*.vsix && rimraf ./*.tgz"

--- a/extensions/tabs/NLUResults.html
+++ b/extensions/tabs/NLUResults.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<head>
+    <script src="../lib/VSS.SDK.min.js"></script>
+    <script type="text/javascript">
+        VSS.init({ 
+            usePlatformScripts: true, 
+            moduleLoaderConfig: { 
+                paths: { 
+                    "enhancer": "scripts" 
+                } 
+            }
+        });
+
+        VSS.ready(() => {
+            const context = VSS.getWebContext();
+            VSS.getConfiguration().onBuildChanged(build =>
+            {
+                VSS.require(["TFS/DistributedTask/TaskRestClient"], module => {
+                    module.getClient().getPlanAttachments(context.project.id, "build", build.orchestrationPlan.planId, "nlu.devops").then(attachments =>
+                    {
+                        let foundMetadata = false;
+                        let foundStatistics = false;
+                        attachments.forEach(attachment => {
+                            if ((attachment.name === "metadata" || attachment.name === "statistics") && attachment._links && attachment._links.self && attachment._links.self.href) {
+                                found = true;
+                                foundMetadata = foundMetadata || attachment.name === "metadata";
+                                foundStatistics = foundStatistics || attachment.name === "statistics";
+                                console.log(attachment._links.self.href);
+                            }
+                        });
+
+                        if (!foundMetadata) {
+                            console.warn("Could not find attachment for NLU metadata.");
+                        }
+
+                        if (!foundMetadata) {
+                            console.warn("Could not find attachment for NLU statistics.");
+                        }
+                    });
+                });
+            });
+        });
+    </script>
+</head>
+    <body>
+        <div class="task-contribution">
+            Hello World!
+        </div>
+    </body>
+</html>

--- a/extensions/tabs/package.json
+++ b/extensions/tabs/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "vss-web-extension-sdk": "^5.141.0"
+    }
+}

--- a/extensions/tasks/NLUTestV0/package.json
+++ b/extensions/tasks/NLUTestV0/package.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
+    "azure-devops-node-api": "^9.0.1",
     "azure-pipelines-task-lib": "^2.8.0",
-    "nlu-devops-common": "file:../../nlu-devops-common-0.1.4.tgz"
+    "nlu-devops-common": "file:../../nlu-devops-common-0.1.4.tgz",
+    "unzip-stream": "^0.3.0"
   }
 }

--- a/extensions/tasks/NLUTestV0/task.json
+++ b/extensions/tasks/NLUTestV0/task.json
@@ -94,6 +94,14 @@
             "helpMarkDown": "Uses generated JSON metadata output from NLU.DevOps `compare` command to populate the NLU results tab. [Learn more about the `compare` command](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Compare.md)."
         },
         {
+            "name": "compareBuildCount",
+            "type": "string",
+            "label": "Number of previous builds to compare against in NLU results.",
+            "helpMarkDown": "Number of previous builds to compare against in NLU results.",
+            "required": false,
+            "defaultValue": "1"
+        },
+        {
             "name": "workingDirectory",
             "type": "filePath",
             "label": "Working Directory",

--- a/extensions/tslint.json
+++ b/extensions/tslint.json
@@ -4,6 +4,8 @@
         "tslint:recommended"
     ],
     "jsRules": {},
-    "rules": {},
+    "rules": {
+        "no-console": false
+    },
     "rulesDirectory": []
 }

--- a/extensions/vss-extension.json
+++ b/extensions/vss-extension.json
@@ -6,6 +6,7 @@
     "description": "A collection of tasks and results tabs for NLU.DevOps",
     "publisher": "NLUDevOps",
     "public": true,
+    "scopes": [ "vso.build" ],
     "icons": {
         "default": "images/icon.png"
     },
@@ -32,6 +33,15 @@
         {
             "path": "tasks/NLUCleanV0",
             "addressable": true
+        },
+        {
+            "path": "tabs/NLUResults.html",
+            "addressable": true
+        },
+        {
+            "path": "tabs/node_modules/vss-web-extension-sdk/lib",
+            "addressable": true,
+            "packagePath": "lib"
         }
     ],
     "contributions": [
@@ -63,6 +73,19 @@
             ],
             "properties": {
                 "name": "tasks/NLUCleanV0"
+            }
+        },
+        {
+            "id": "nlu-results-tab",
+            "type": "ms.vss-build-web.build-results-tab",
+            "description": "A tab for displaying NLU results dependent on the NLUClean task",
+            "targets": [
+                "ms.vss-build-web.build-results-view"
+            ],
+            "properties": {
+                "name": "NLU Results",
+                 "uri": "tabs/NLUResults.html",
+                 "supportsTasks": ["b05f23dd-168e-475a-a6f9-6297f8fd21bc"]
             }
         }
     ],

--- a/models/luismodel.json
+++ b/models/luismodel.json
@@ -1,0 +1,73 @@
+{
+    "luis_schema_version": "3.2.0",
+    "versionId": "0.1",
+    "name": "nludevopsmodel",
+    "desc": "",
+    "culture": "en-us",
+    "tokenizerVersion": "1.0.0",
+    "intents": [
+      {
+        "name": "None"
+      },
+      {
+        "name": "PlayMusic"
+      }
+    ],
+    "entities": [],
+    "composites": [],
+    "closedLists": [],
+    "patternAnyEntities": [],
+    "regex_entities": [],
+    "prebuiltEntities": [],
+    "model_features": [],
+    "regex_features": [],
+    "patterns": [],
+    "utterances": [
+      {
+        "text": "barking dogs are annoying",
+        "intent": "None",
+        "entities": []
+      },
+      {
+        "text": "book a flight to ukraine",
+        "intent": "None",
+        "entities": []
+      },
+      {
+        "text": "call the pizza place",
+        "intent": "None",
+        "entities": []
+      },
+      {
+        "text": "music please",
+        "intent": "PlayMusic",
+        "entities": []
+      },
+      {
+        "text": "penguins in the ocean",
+        "intent": "None",
+        "entities": []
+      },
+      {
+        "text": "play me some good music",
+        "intent": "PlayMusic",
+        "entities": []
+      },
+      {
+        "text": "play music",
+        "intent": "PlayMusic",
+        "entities": []
+      },
+      {
+        "text": "start playing music",
+        "intent": "PlayMusic",
+        "entities": []
+      },
+      {
+        "text": "when does your store open",
+        "intent": "None",
+        "entities": []
+      }
+    ],
+    "settings": []
+  }

--- a/pipelines/test-release.yml
+++ b/pipelines/test-release.yml
@@ -17,6 +17,7 @@ stages:
         service: luis
         utterances: models/tests.json
         publishTestResults: true
+        publishNLUResults: true
     - task: NLUClean@0
       inputs:
         service: luis  

--- a/pipelines/test-release.yml
+++ b/pipelines/test-release.yml
@@ -1,26 +1,33 @@
 trigger:
   branches:
-    include:
-    - master
-  paths:
-    include:
-    - /extensions/
-    - /pipelines/extension-build.yml
-pr:
-  branches:
-    include:
-    - master
-  paths:
-    include:
-    - /extensions/
-    - /pipelines/extension-build.yml
+    exclude:
+    - '*'
 
 stages:
-- stage: Build
+- stage: Test
   jobs:
-  - job: buildvsix
+  - job: testextension 
+    steps:
+    - task: NLUTrain@0
+      inputs: 
+        service: luis
+        modelSettings: models/luismodel.json
+    - task: NLUTest@0
+      inputs:
+        service: luis
+        utterances: models/tests.json
+        publishTestResults: true
+    - task: NLUClean@0
+      inputs:
+        service: luis  
+
+- stage: Release
+  dependsOn: Test
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  jobs:
+  - job: releaseextension
     pool:
-      vmImage: 'ubuntu-latest' 
+      vmImage: 'ubuntu-latest'
     steps:
     - task: NPM@1
       displayName: npm install
@@ -65,33 +72,6 @@ stages:
         fileType: vsix
         vsixFile: '**/*.vsix'
         publisherId: NLUDevOps
-        extensionId: NLUDevOpsCI
-        extensionName: NLU.DevOps.CI
         extensionVersion: '0.1.$(Build.BuildId)'
         updateTasksVersion: true
-        extensionVisibility: private
-        shareWith: NLUDevOps
-
-- stage: Wait
-  dependsOn: Build
-  jobs:
-  - job: waitforvsix
-    pool: server
-    steps:
-    - task: Delay@1
-      inputs: 
-        delayForMinutes: 1
-
-- stage: Trigger
-  dependsOn: Wait
-  jobs:
-  - job: triggertest  
-    steps: 
-    - task: maikvandergaag.maikvandergaag-trigger-pipeline.TriggerPipeline.TriggerPipeline@1
-      displayName: 'Trigger Azure DevOps Pipeline: test and release'
-      inputs:
-        serviceConnection: TriggerConnectionFull
-        project: 'NLU.DevOps'
-        Pipeline: Build
-        buildDefinition: 'Azure DevOps Extension - test and release'
-        Branch: $(Build.SourceBranch)
+        extensionVisibility: public


### PR DESCRIPTION
Includes the following changes:
1. Adds `metadata.json` result from the `compare` command as an attachment to the build pipeline.
2. Publishes `statistics.json` from the `compare` command as a build artifact to a container called `statistics` for `master` branch builds.
3. When `statistics.json` is published from a `master` branch build, adds a `nlu.devops.statistics` tag to the build so it can be queried for later.
4. Queries for the previous N (specified by user) builds with the `nlu.devops.statistics` tag, downloads their artifact archive and unzips.
5. Merges the `statistics.json` artifact from previous builds with the `statistics.json` for the current build.
6. Adds the merged `statistics.json` as an attachment to the build pipeline.
7. Adds a very basic Azure Pipelines web extension that looks for `metadata` and `statistics` attachments from the current pipeline and console.log's the link to those attachments.