### PR TITLE
Adds path resolution for ServiceResolver

### DIFF
--- a/src/NLU.DevOps.CommandLine/ServiceResolver.cs
+++ b/src/NLU.DevOps.CommandLine/ServiceResolver.cs
@@ -44,7 +44,8 @@ namespace NLU.DevOps.CommandLine
                 }
             }
 
-            var assemblyPath = options.IncludePath ?? getAssemblyPath();
+            var includePath = options.IncludePath != null ? Path.GetFullPath(options.IncludePath) : null;
+            var assemblyPath = includePath ?? getAssemblyPath();
             if (assemblyPath == null)
             {
                 instance = default(T);


### PR DESCRIPTION
The `Assembly.Load` call for dynamic assembly resolution expects a full path, so adding call to `Path.GetFullPath` to enable relative paths in the `--include` CLI option.

Fixes #143