### PR TITLE
Adds 'include' input to NLU.DevOps AzDO tasks

### DIFF
--- a/docs/Clean.md
+++ b/docs/Clean.md
@@ -16,6 +16,9 @@ To make things easier, be sure to use the [`--save-appsettings`](Train.md#-a---s
 ### `-s, --service`
 Identifier of the NLU provider to run against. Try `luis` for [LUIS](https://www.luis.ai) or `lex` for [Lex](https://aws.amazon.com/lex/).
 
+### `-i, --include`
+(Optional) Path to custom NLU provider DLL. See documentation about [Specifying the include path](https://github.com/microsoft/NLU.DevOps/blob/master/docs/CliExtensions.md#specifying-the-include-path) for more details.
+
 ### `-a, --delete-appsettings`
 
 (Optional) Delete the NLU provider-specific configuration overrides that were generated using the `--save-appsettings` option in a `train` command.

--- a/docs/NLUCleanTask.md
+++ b/docs/NLUCleanTask.md
@@ -11,6 +11,7 @@ See the endpoint configuration documentation for [LUIS](LuisEndpointConfiguratio
 
 Inputs to consider when using the `NLUClean` task:
 - [`service`](#service)
+- [`includePath`](#includepath)
 - [`workingDirectory`](#workingdirectory)
 - [`nupkgPath`](#nupkgpath)
 - [`toolVersion`](#toolversion)
@@ -19,16 +20,19 @@ Inputs to consider when using the `NLUClean` task:
 
 ### `service`
 
-Required. Specifies the NLU provider to use when deleting the model. Works for `luis`, `luisV3` and `lex`.
+Specifies the NLU provider to use when deleting the model. Works for `luis`, `luisV3` and `lex`.
+
+### `includePath`
+(Optional) Path to custom NLU provider DLL. See documentation about [Specifying the include path](https://github.com/microsoft/NLU.DevOps/blob/master/docs/CliExtensions.md#specifying-the-include-path) for more details.
 
 ### `workingDirectory`
 
-Optional. Specifies the working directory to use when running the `clean` command. This task only works if you have previously used the [`NLUTrain` task](NLUTrainTask.md) from the same working directory. Defaults to the Azure DevOps default working directory (i.e., the root directory of the repository).
+(Optional) Specifies the working directory to use when running the `clean` command. This task only works if you have previously used the [`NLUTrain` task](NLUTrainTask.md) from the same working directory. Defaults to the Azure DevOps default working directory (i.e., the root directory of the repository).
 
 ### `nupkgPath`
 
-Optional. Specifies the folder containing a `.nupkg` for `dotnet-nlu` to install from. When not specified, `dotnet-nlu` is installed from the default NuGet repository.
+(Optional) Specifies the folder containing a `.nupkg` for `dotnet-nlu` to install from. When not specified, `dotnet-nlu` is installed from the default NuGet repository.
 
 ### `toolVersion`
 
-Optional. Specifies the version of `dotnet-nlu` to install from the default NuGet repository. You cannot specify both the [`nupkgPath`](#nupkgpath) input and `toolVersion`.
+(Optional) Specifies the version of `dotnet-nlu` to install from the default NuGet repository. You cannot specify both the [`nupkgPath`](#nupkgpath) input and `toolVersion`.

--- a/docs/NLUTestTask.md
+++ b/docs/NLUTestTask.md
@@ -26,6 +26,7 @@ Inputs to consider when using the `NLUTest` task:
 - [`speech`](#speech)
 - [`speechDirectory`](#speechdirectory)
 - [`output`](#output)
+- [`includePath`](#includepath)
 - [`compareOutput`](#compareoutput)
 - [`publishTestResults`](#publishtestresults)
 - [`publishNLUResults`](#publishnluresults)
@@ -37,48 +38,51 @@ Inputs to consider when using the `NLUTest` task:
 
 ### `service`
 
-Required. Specifies the NLU provider to use when deleting the model. Works for `luis`, `luisV3`, `dialogflow` and `lex`.
+Specifies the NLU provider to use when deleting the model. Works for `luis`, `luisV3`, `dialogflow` and `lex`.
 
 ### `utterances`
 
-Required. Specifies the path to the labeled test utterances relative to the [`workingDirectory`](#workingdirectory).
+Specifies the path to the labeled test utterances relative to the [`workingDirectory`](#workingdirectory).
 
 ### `modelSettings`
 
-Optional. Specifies the path to the model settings, relative to the [`workingDirectory`](#workingdirectory). Currently only used for [LUIS prebuilt entity mappings](LuisModelConfiguration.md#configuring-prebuilt-entities).
+(Optional) Specifies the path to the model settings, relative to the [`workingDirectory`](#workingdirectory). Currently only used for [LUIS prebuilt entity mappings](LuisModelConfiguration.md#configuring-prebuilt-entities).
 
 ### `speech`
 
-Optional. Specifies whether the tests should be run from speech utterances instead of text utterances. Default value is `false`.
+(Optional) Specifies whether the tests should be run from speech utterances instead of text utterances. Default value is `false`.
 
 ### `speechDirectory`
 
-Optional. Specifies the base path for speech files referenced in the [`utterances`](#utterances) input, relative to the [`workingDirectory`](#workingdirectory).
+(Optional) Specifies the base path for speech files referenced in the [`utterances`](#utterances) input, relative to the [`workingDirectory`](#workingdirectory).
 
 ### `output`
 
-Optional. Specifies the output path for the results from testing the NLU model, relative to the [`workingDirectory`](#workingdirectory). Defaults to `$(Agent.TempDirectory)/.nlu/results.json`.
+(Optional) Specifies the output path for the results from testing the NLU model, relative to the [`workingDirectory`](#workingdirectory). Defaults to `$(Agent.TempDirectory)/.nlu/results.json`.
+
+### `includePath`
+(Optional) Path to custom NLU provider DLL. See documentation about [Specifying the include path](https://github.com/microsoft/NLU.DevOps/blob/master/docs/CliExtensions.md#specifying-the-include-path) for more details.
 
 ### `compareOutput`
 
-Optional. Specifies the output path for the results from comparing the NLU model test results to the expected output in the [`utterances`](#utterances) input, relative to the [`workingDirectory`](#workingdirectory). Defaults to `$(Agent.TempDirectory)/.nlu`.
+(Optional) Specifies the output path for the results from comparing the NLU model test results to the expected output in the [`utterances`](#utterances) input, relative to the [`workingDirectory`](#workingdirectory). Defaults to `$(Agent.TempDirectory)/.nlu`.
 
 ### `publishTestResults`
 
-Optional. Boolean value that specifies whether the comparison results between the NLU model output and the [`utterances`](#utterances) input should be published to the Tests tab for the Azure Pipeline. Defaults to `false`.
+(Optional) Boolean value that specifies whether the comparison results between the NLU model output and the [`utterances`](#utterances) input should be published to the Tests tab for the Azure Pipeline. Defaults to `false`.
 
 ### `publishNLUResults`
 
-Optional. Boolean value that specifies whether the comparison results should output metadata for the confusion matrix for intents, entities and text. Defaults to `false`.
+(Optional) Boolean value that specifies whether the comparison results should output metadata for the confusion matrix for intents, entities and text. Defaults to `false`.
 
 ### `workingDirectory`
 
-Optional. Specifies the working directory to use when running the `test` command. Defaults to the Azure DevOps default working directory (i.e., the root directory of the repository).
+(Optional) Specifies the working directory to use when running the `test` command. Defaults to the Azure DevOps default working directory (i.e., the root directory of the repository).
 
 ### `nupkgPath`
 
-Optional. Specifies the folder containing a `.nupkg` for `dotnet-nlu` to install from. When not specified, `dotnet-nlu` is installed from the default NuGet repository.
+(Optional) Specifies the folder containing a `.nupkg` for `dotnet-nlu` to install from. When not specified, `dotnet-nlu` is installed from the default NuGet repository.
 
 ### `toolVersion`
 
-Optional. Specifies the version of `dotnet-nlu` to install from the default NuGet repository. You cannot specify both the [`nupkgPath`](#nupkgpath) input and `toolVersion`.
+(Optional) Specifies the version of `dotnet-nlu` to install from the default NuGet repository. You cannot specify both the [`nupkgPath`](#nupkgpath) input and `toolVersion`.

--- a/docs/NLUTrainTask.md
+++ b/docs/NLUTrainTask.md
@@ -16,6 +16,7 @@ Inputs to consider when using the `NLUClean` task:
 - [`service`](#service)
 - [`utterances`](#utterances)
 - [`modelSettings`](#modelsettings)
+- [`includePath`](#includepath)
 - [`workingDirectory`](#workingdirectory)
 - [`nupkgPath`](#nupkgpath)
 - [`toolVersion`](#toolversion)
@@ -24,24 +25,27 @@ Inputs to consider when using the `NLUClean` task:
 
 ### `service`
 
-Required. Specifies the NLU provider to use when deleting the model. Works for `luis`, `luisV3` and `lex`.
+Specifies the NLU provider to use when deleting the model. Works for `luis`, `luisV3` and `lex`.
 
 ### `utterances`
 
-Optional. The path to the JSON array of generic utterances to include when training the model, relative to the [`workingDirectory`](#workingdirectory).
+(Optional) The path to the JSON array of generic utterances to include when training the model, relative to the [`workingDirectory`](#workingdirectory).
 
 ### `modelSettings`
 
-Optional. The path to the model settings file, relative to the [`workingDirectory`](#workingdirectory). Find more information on configuring the model settings for [LUIS](LuisModelConfiguration.md) and [Lex](LexModelConfiguration.md).
+(Optional) The path to the model settings file, relative to the [`workingDirectory`](#workingdirectory). Find more information on configuring the model settings for [LUIS](LuisModelConfiguration.md) and [Lex](LexModelConfiguration.md).
+
+### `includePath`
+(Optional) Path to custom NLU provider DLL. See documentation about [Specifying the include path](https://github.com/microsoft/NLU.DevOps/blob/master/docs/CliExtensions.md#specifying-the-include-path) for more details.
 
 ### `workingDirectory`
 
-Optional. Specifies the working directory to use when running the `train` command. Defaults to the Azure DevOps default working directory (i.e., the root directory of the repository).
+(Optional) Specifies the working directory to use when running the `train` command. Defaults to the Azure DevOps default working directory (i.e., the root directory of the repository).
 
 ### `nupkgPath`
 
-Optional. Specifies the folder containing a `.nupkg` for `dotnet-nlu` to install from. When not specified, `dotnet-nlu` is installed from the default NuGet repository.
+(Optional) Specifies the folder containing a `.nupkg` for `dotnet-nlu` to install from. When not specified, `dotnet-nlu` is installed from the default NuGet repository.
 
 ### `toolVersion`
 
-Optional. Specifies the version of `dotnet-nlu` to install from the default NuGet repository. You cannot specify both the [`nupkgPath`](#nupkgpath) input and `toolVersion`.
+(Optional) Specifies the version of `dotnet-nlu` to install from the default NuGet repository. You cannot specify both the [`nupkgPath`](#nupkgpath) input and `toolVersion`.

--- a/docs/Test.md
+++ b/docs/Test.md
@@ -153,6 +153,9 @@ See [Caching speech-to-text transcriptions](#caching-speech-to-text-transcriptio
 
 This is currently only used for LUIS, see the section on LUIS prebuilt entities in [Configuring prebuilt entities](LuisModelConfiguration.md#configuring-prebuilt-entities).
 
+### `-i, --include`
+(Optional) Path to custom NLU provider DLL. See documentation about [Specifying the include path](https://github.com/microsoft/NLU.DevOps/blob/master/docs/CliExtensions.md#specifying-the-include-path) for more details.
+
 ### `-v, --verbose`
 
 (Optional) Use verbose logging when running the command.

--- a/docs/Train.md
+++ b/docs/Train.md
@@ -128,6 +128,9 @@ The `settings.luis.json` file in this case will be merged into the generated LUI
 
 See [LUIS App Configuration](LuisModelConfiguration.md) and [Lex App Configuration](LexModelConfiguration.md) for additional information on the kinds of settings, including entity types, that are supplied through this file.
 
+### `-i, --include`
+(Optional) Path to custom NLU provider DLL. See documentation about [Specifying the include path](https://github.com/microsoft/NLU.DevOps/blob/master/docs/CliExtensions.md#specifying-the-include-path) for more details.
+
 ### `-a, --save-appsettings`
 
 (Optional) Output additional appsettings for resources that were created by the train command for use in subsequent commands.

--- a/extensions/tasks/NLUCleanV0/index.ts
+++ b/extensions/tasks/NLUCleanV0/index.ts
@@ -11,6 +11,12 @@ async function run() {
             .arg("-a")
             .arg("-v");
 
+        const includePath = tl.getInput("includePath");
+        if (includePath) {
+            tool.arg("-i")
+                .arg(includePath);
+        }
+
         let isError = false;
         tool.on("stderr", () => {
             isError = true;

--- a/extensions/tasks/NLUCleanV0/task.json
+++ b/extensions/tasks/NLUCleanV0/task.json
@@ -31,6 +31,13 @@
             "helpMarkDown": "Usually one of: 'luis', 'luisV3', or 'lex'."
         },
         {
+            "name": "includePath",
+            "type": "string",
+            "label": "NLU.DevOps custom NLU provider include path.",
+            "required": false,
+            "helpMarkDown": "[Learn more about this option](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Clean.md#include)."
+        },
+        {
             "name": "workingDirectory",
             "type": "filePath",
             "label": "Working Directory",

--- a/extensions/tasks/NLUTestV0/index.ts
+++ b/extensions/tasks/NLUTestV0/index.ts
@@ -41,6 +41,12 @@ async function runNLUTest(output): Promise<any> {
             .arg(speechDirectory);
     }
 
+    const includePath = tl.getInput("includePath");
+    if (includePath) {
+        tool.arg("-i")
+            .arg(includePath);
+    }
+
     let isError = false;
     tool.on("stderr", () => {
         isError = true;

--- a/extensions/tasks/NLUTestV0/task.json
+++ b/extensions/tasks/NLUTestV0/task.json
@@ -70,6 +70,13 @@
             "helpMarkDown": "[Learn more about this option](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Test.md#-d---speech-directory)."
         },
         {
+            "name": "includePath",
+            "type": "string",
+            "label": "NLU.DevOps custom NLU provider include path.",
+            "required": false,
+            "helpMarkDown": "[Learn more about this option](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Test.md#include)."
+        },
+        {
             "name": "compareOutput",
             "type": "string",
             "label": "Base directory where compare output will be stored.",

--- a/extensions/tasks/NLUTrainV0/index.ts
+++ b/extensions/tasks/NLUTrainV0/index.ts
@@ -23,6 +23,12 @@ async function run() {
                 .arg(modelSettings);
         }
 
+        const includePath = tl.getInput("includePath");
+        if (includePath) {
+            tool.arg("-i")
+                .arg(includePath);
+        }
+
         if (!utterances && !modelSettings) {
             throw new Error("Must provide either 'utterances' or 'modelSetting' task input.");
         }

--- a/extensions/tasks/NLUTrainV0/task.json
+++ b/extensions/tasks/NLUTrainV0/task.json
@@ -45,6 +45,13 @@
             "helpMarkDown": "[Learn more about this option](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Train.md#-m---model-settings)."
         },
         {
+            "name": "includePath",
+            "type": "string",
+            "label": "NLU.DevOps custom NLU provider include path.",
+            "required": false,
+            "helpMarkDown": "[Learn more about this option](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Train.md#include)."
+        },
+        {
             "name": "workingDirectory",
             "type": "filePath",
             "label": "Working Directory",


### PR DESCRIPTION
Adds the `--include` CLI option to NLU.DevOps AzDO extension tasks. This option is used to specify the location of the DLL used to load a custom NLU provider.

Fixes #133