### PR TITLE
Removes "All rights reserved." from copyright headers

### DIFF
--- a/docs/CliExtensions.md
+++ b/docs/CliExtensions.md
@@ -26,7 +26,7 @@ Open the project in [Visual Studio](https://visualstudio.microsoft.com/downloads
 
 Add `MockNLUClient.cs` to your project:
 ```cs
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.MockProvider
@@ -88,7 +88,7 @@ namespace NLU.DevOps.MockProvider
 ### 4. Implement `INLUClientFactory`
 Add `MockNLUClientFactory.cs` to your project:
 ```cs
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.MockProvider

--- a/src/CommonNuget.props
+++ b/src/CommonNuget.props
@@ -7,7 +7,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/Microsoft/NLU.DevOps</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Microsoft/NLU.DevOps.git</RepositoryUrl>
-    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <Copyright>© Microsoft Corporation.</Copyright>
     <Version>0.4.1</Version>
   </PropertyGroup>
 </Project>

--- a/src/NLU.DevOps.CommandLine.Tests/BaseCommandMock.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/BaseCommandMock.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Tests

--- a/src/NLU.DevOps.CommandLine.Tests/BaseCommandTests.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/BaseCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Tests

--- a/src/NLU.DevOps.CommandLine.Tests/BaseOptionsTests.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/BaseOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Tests

--- a/src/NLU.DevOps.CommandLine.Tests/Clean/CleanCommandMock.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/Clean/CleanCommandMock.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Tests.Clean

--- a/src/NLU.DevOps.CommandLine.Tests/Clean/CleanCommandTests.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/Clean/CleanCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Tests.Clean

--- a/src/NLU.DevOps.CommandLine.Tests/Clean/CleanOptionsTests.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/Clean/CleanOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Tests.Clean

--- a/src/NLU.DevOps.CommandLine.Tests/Compare/CompareOptionsTests.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/Compare/CompareOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Tests.Compare

--- a/src/NLU.DevOps.CommandLine.Tests/GlobalSuppressions.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1812:Avoid uninstantiated internal classes", Justification = "NUnit will instantiate this instance through reflection.", Scope = "type", Target = "~T:NLU.DevOps.CommandLine.Tests.BaseCommandTests")]

--- a/src/NLU.DevOps.CommandLine.Tests/MockNLUTrainClient.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/MockNLUTrainClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Tests

--- a/src/NLU.DevOps.CommandLine.Tests/NLUServiceFactoryTests.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/NLUServiceFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Tests

--- a/src/NLU.DevOps.CommandLine.Tests/SerializerTests.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/SerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Tests

--- a/src/NLU.DevOps.CommandLine.Tests/Test/TestCommandTests.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/Test/TestCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Tests.Test

--- a/src/NLU.DevOps.CommandLine.Tests/Test/TestOptionsTests.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/Test/TestOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Tests.Test

--- a/src/NLU.DevOps.CommandLine.Tests/Train/TrainCommandMock.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/Train/TrainCommandMock.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Tests.Train

--- a/src/NLU.DevOps.CommandLine.Tests/Train/TrainCommandTests.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/Train/TrainCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Tests.Train

--- a/src/NLU.DevOps.CommandLine.Tests/Train/TrainOptionsTests.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/Train/TrainOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Tests.Train

--- a/src/NLU.DevOps.CommandLine/BaseCommand.cs
+++ b/src/NLU.DevOps.CommandLine/BaseCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine

--- a/src/NLU.DevOps.CommandLine/BaseOptions.cs
+++ b/src/NLU.DevOps.CommandLine/BaseOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine

--- a/src/NLU.DevOps.CommandLine/Clean/CleanCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Clean/CleanCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Clean

--- a/src/NLU.DevOps.CommandLine/Clean/CleanOptions.cs
+++ b/src/NLU.DevOps.CommandLine/Clean/CleanOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Clean

--- a/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Compare

--- a/src/NLU.DevOps.CommandLine/Compare/CompareOptions.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Compare

--- a/src/NLU.DevOps.CommandLine/EnumerableExtensions.cs
+++ b/src/NLU.DevOps.CommandLine/EnumerableExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine

--- a/src/NLU.DevOps.CommandLine/GlobalSuppressions.cs
+++ b/src/NLU.DevOps.CommandLine/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1812:Avoid uninstantiated internal classes", Justification = "The class is passed as a generic type parameter that has a new constraint.", Scope = "type", Target = "~T:NLU.DevOps.CommandLine.Clean.CleanOptions")]

--- a/src/NLU.DevOps.CommandLine/ICommand.cs
+++ b/src/NLU.DevOps.CommandLine/ICommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine

--- a/src/NLU.DevOps.CommandLine/NLUClientFactory.cs
+++ b/src/NLU.DevOps.CommandLine/NLUClientFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine

--- a/src/NLU.DevOps.CommandLine/Program.cs
+++ b/src/NLU.DevOps.CommandLine/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine

--- a/src/NLU.DevOps.CommandLine/Properties/AssemblyInfo.cs
+++ b/src/NLU.DevOps.CommandLine/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Runtime.CompilerServices;

--- a/src/NLU.DevOps.CommandLine/Serializer.cs
+++ b/src/NLU.DevOps.CommandLine/Serializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 namespace NLU.DevOps.CommandLine
 {

--- a/src/NLU.DevOps.CommandLine/ServiceResolver.cs
+++ b/src/NLU.DevOps.CommandLine/ServiceResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine

--- a/src/NLU.DevOps.CommandLine/Test/TestCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Test/TestCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Test

--- a/src/NLU.DevOps.CommandLine/Test/TestOptions.cs
+++ b/src/NLU.DevOps.CommandLine/Test/TestOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Test

--- a/src/NLU.DevOps.CommandLine/Train/TrainCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Train/TrainCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Train

--- a/src/NLU.DevOps.CommandLine/Train/TrainOptions.cs
+++ b/src/NLU.DevOps.CommandLine/Train/TrainOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Train

--- a/src/NLU.DevOps.Core.Tests/GlobalSuppressions.cs
+++ b/src/NLU.DevOps.Core.Tests/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1812:Avoid uninstantiated internal classes", Justification = "NUnit will instantiate this instance through reflection.", Scope = "type", Target = "~T:NLU.DevOps.Core.Tests.LabeledUtteranceConverterTests")]

--- a/src/NLU.DevOps.Core.Tests/LabeledUtteranceConverterTests.cs
+++ b/src/NLU.DevOps.Core.Tests/LabeledUtteranceConverterTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Core.Tests

--- a/src/NLU.DevOps.Core/ApplicationLogger.cs
+++ b/src/NLU.DevOps.Core/ApplicationLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Logging

--- a/src/NLU.DevOps.Core/DefaultNLUTestClient.cs
+++ b/src/NLU.DevOps.Core/DefaultNLUTestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Core

--- a/src/NLU.DevOps.Core/DefaultQuery.cs
+++ b/src/NLU.DevOps.Core/DefaultQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Core

--- a/src/NLU.DevOps.Core/EntityExtensions.cs
+++ b/src/NLU.DevOps.Core/EntityExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Models

--- a/src/NLU.DevOps.Core/INLUClientFactory.cs
+++ b/src/NLU.DevOps.Core/INLUClientFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Models

--- a/src/NLU.DevOps.Core/LabeledUtteranceConverter.cs
+++ b/src/NLU.DevOps.Core/LabeledUtteranceConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Core

--- a/src/NLU.DevOps.Core/NLUTestClientBase.cs
+++ b/src/NLU.DevOps.Core/NLUTestClientBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Core

--- a/src/NLU.DevOps.Dialogflow.Tests/DialogflowNLUTestClientFactoryTests.cs
+++ b/src/NLU.DevOps.Dialogflow.Tests/DialogflowNLUTestClientFactoryTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Dialogflow.Tests

--- a/src/NLU.DevOps.Dialogflow.Tests/DialogflowNLUTestClientTests.cs
+++ b/src/NLU.DevOps.Dialogflow.Tests/DialogflowNLUTestClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Dialogflow.Tests

--- a/src/NLU.DevOps.Dialogflow.Tests/GlobalSuppressions.cs
+++ b/src/NLU.DevOps.Dialogflow.Tests/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1806:Do not ignore method results", Justification = "Creating the object results in a tested exception.", Scope = "member", Target = "~M:NLU.DevOps.Dialogflow.Tests.DialogflowNLUTestClientTests.ThrowsArgumentNull")]

--- a/src/NLU.DevOps.Dialogflow/DialogflowNLUClientFactory.cs
+++ b/src/NLU.DevOps.Dialogflow/DialogflowNLUClientFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Dialogflow

--- a/src/NLU.DevOps.Dialogflow/DialogflowNLUTestClient.cs
+++ b/src/NLU.DevOps.Dialogflow/DialogflowNLUTestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Dialogflow

--- a/src/NLU.DevOps.Dialogflow/Properties/AssemblyInfo.cs
+++ b/src/NLU.DevOps.Dialogflow/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Runtime.CompilerServices;

--- a/src/NLU.DevOps.Lex.Tests/GlobalSuppressions.cs
+++ b/src/NLU.DevOps.Lex.Tests/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1806:Do not ignore method results", Justification = "Creating the object results in a tested exception.", Scope = "member", Target = "~M:NLU.DevOps.Lex.Tests.LexNLUTrainClientTests.ThrowsArgumentNull")]

--- a/src/NLU.DevOps.Lex.Tests/LexNLUClientExtensions.cs
+++ b/src/NLU.DevOps.Lex.Tests/LexNLUClientExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Lex.Tests

--- a/src/NLU.DevOps.Lex.Tests/LexNLUClientFactoryTests.cs
+++ b/src/NLU.DevOps.Lex.Tests/LexNLUClientFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Lex.Tests

--- a/src/NLU.DevOps.Lex.Tests/LexNLUTestClientTests.cs
+++ b/src/NLU.DevOps.Lex.Tests/LexNLUTestClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Lex.Tests

--- a/src/NLU.DevOps.Lex.Tests/LexNLUTrainClientTests.cs
+++ b/src/NLU.DevOps.Lex.Tests/LexNLUTrainClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Lex.Tests

--- a/src/NLU.DevOps.Lex/EntityType.cs
+++ b/src/NLU.DevOps.Lex/EntityType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Lex

--- a/src/NLU.DevOps.Lex/ILexTestClient.cs
+++ b/src/NLU.DevOps.Lex/ILexTestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Lex

--- a/src/NLU.DevOps.Lex/ILexTrainClient.cs
+++ b/src/NLU.DevOps.Lex/ILexTrainClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Lex

--- a/src/NLU.DevOps.Lex/ImportBotTemplates.cs
+++ b/src/NLU.DevOps.Lex/ImportBotTemplates.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Lex

--- a/src/NLU.DevOps.Lex/JTokenExtensions.cs
+++ b/src/NLU.DevOps.Lex/JTokenExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Lex

--- a/src/NLU.DevOps.Lex/LexNLUClientFactory.cs
+++ b/src/NLU.DevOps.Lex/LexNLUClientFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Lex

--- a/src/NLU.DevOps.Lex/LexNLUTestClient.cs
+++ b/src/NLU.DevOps.Lex/LexNLUTestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Lex

--- a/src/NLU.DevOps.Lex/LexNLUTrainClient.cs
+++ b/src/NLU.DevOps.Lex/LexNLUTrainClient.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Lex

--- a/src/NLU.DevOps.Lex/LexSettings.cs
+++ b/src/NLU.DevOps.Lex/LexSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Lex

--- a/src/NLU.DevOps.Lex/LexTestClient.cs
+++ b/src/NLU.DevOps.Lex/LexTestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Lex

--- a/src/NLU.DevOps.Lex/LexTrainClient.cs
+++ b/src/NLU.DevOps.Lex/LexTrainClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Lex

--- a/src/NLU.DevOps.Luis.Shared/AzureSubscriptionInfo.cs
+++ b/src/NLU.DevOps.Luis.Shared/AzureSubscriptionInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.Luis.Shared/ILuisConfiguration.cs
+++ b/src/NLU.DevOps.Luis.Shared/ILuisConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.Luis.Shared/ILuisTrainClient.cs
+++ b/src/NLU.DevOps.Luis.Shared/ILuisTrainClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.Luis.Shared/LabeledUtteranceExtensions.cs
+++ b/src/NLU.DevOps.Luis.Shared/LabeledUtteranceExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.Luis.Shared/LuisConfiguration.cs
+++ b/src/NLU.DevOps.Luis.Shared/LuisConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.Luis.Shared/LuisNLUTrainClient.cs
+++ b/src/NLU.DevOps.Luis.Shared/LuisNLUTrainClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.Luis.Shared/LuisSettings.cs
+++ b/src/NLU.DevOps.Luis.Shared/LuisSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.Luis.Shared/LuisTrainClient.cs
+++ b/src/NLU.DevOps.Luis.Shared/LuisTrainClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.Luis.Shared/ScoredEntity.cs
+++ b/src/NLU.DevOps.Luis.Shared/ScoredEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.Luis.Shared/ScoredLabeledUtterance.cs
+++ b/src/NLU.DevOps.Luis.Shared/ScoredLabeledUtterance.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.Luis.Shared/TestLuisConfiguration.cs
+++ b/src/NLU.DevOps.Luis.Shared/TestLuisConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.Luis.Tests.Shared/GlobalSuppressions.cs
+++ b/src/NLU.DevOps.Luis.Tests.Shared/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1806:Do not ignore method results", Justification = "Creating the object results in a tested exception.", Scope = "member", Target = "~M:NLU.DevOps.Luis.Tests.LuisConfigurationTests.ThrowsArgumentNull")]

--- a/src/NLU.DevOps.Luis.Tests.Shared/LuisConfigurationTests.cs
+++ b/src/NLU.DevOps.Luis.Tests.Shared/LuisConfigurationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis.Tests

--- a/src/NLU.DevOps.Luis.Tests.Shared/LuisNLUClientFactoryTests.cs
+++ b/src/NLU.DevOps.Luis.Tests.Shared/LuisNLUClientFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis.Tests

--- a/src/NLU.DevOps.Luis.Tests.Shared/LuisNLUTestClientExtensions.cs
+++ b/src/NLU.DevOps.Luis.Tests.Shared/LuisNLUTestClientExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis.Tests

--- a/src/NLU.DevOps.Luis.Tests.Shared/LuisNLUTrainClientTests.cs
+++ b/src/NLU.DevOps.Luis.Tests.Shared/LuisNLUTrainClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis.Tests

--- a/src/NLU.DevOps.Luis.Tests.Shared/LuisSettingsTests.cs
+++ b/src/NLU.DevOps.Luis.Tests.Shared/LuisSettingsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis.Tests

--- a/src/NLU.DevOps.Luis.Tests.Shared/TestLuisConfigurationTests.cs
+++ b/src/NLU.DevOps.Luis.Tests.Shared/TestLuisConfigurationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis.Tests

--- a/src/NLU.DevOps.Luis.Tests/LuisNLUTestClientTests.cs
+++ b/src/NLU.DevOps.Luis.Tests/LuisNLUTestClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis.Tests

--- a/src/NLU.DevOps.Luis/ILuisTestClient.cs
+++ b/src/NLU.DevOps.Luis/ILuisTestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.Luis/LuisNLUClientFactory.cs
+++ b/src/NLU.DevOps.Luis/LuisNLUClientFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.Luis/LuisTestClient.cs
+++ b/src/NLU.DevOps.Luis/LuisTestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.Luis/SpeechLuisResult.cs
+++ b/src/NLU.DevOps.Luis/SpeechLuisResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.LuisV3.Tests/LuisNLUTestClientTests.cs
+++ b/src/NLU.DevOps.LuisV3.Tests/LuisNLUTestClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis.Tests

--- a/src/NLU.DevOps.LuisV3/ILuisTestClient.cs
+++ b/src/NLU.DevOps.LuisV3/ILuisTestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.LuisV3/LuisNLUClientFactory.cs
+++ b/src/NLU.DevOps.LuisV3/LuisNLUClientFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.LuisV3/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.LuisV3/LuisNLUTestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.LuisV3/LuisTestClient.cs
+++ b/src/NLU.DevOps.LuisV3/LuisTestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.LuisV3/SpeechPredictionResponse.cs
+++ b/src/NLU.DevOps.LuisV3/SpeechPredictionResponse.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Luis

--- a/src/NLU.DevOps.MockProvider/MockNLUClient.cs
+++ b/src/NLU.DevOps.MockProvider/MockNLUClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.MockProvider

--- a/src/NLU.DevOps.MockProvider/MockNLUClientFactory.cs
+++ b/src/NLU.DevOps.MockProvider/MockNLUClientFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.MockProvider

--- a/src/NLU.DevOps.MockProvider/Program.cs
+++ b/src/NLU.DevOps.MockProvider/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.MockProvider

--- a/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.ModelPerformance.Tests

--- a/src/NLU.DevOps.ModelPerformance/ComparisonTargetKind.cs
+++ b/src/NLU.DevOps.ModelPerformance/ComparisonTargetKind.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.ModelPerformance

--- a/src/NLU.DevOps.ModelPerformance/ConfigurationConstants.cs
+++ b/src/NLU.DevOps.ModelPerformance/ConfigurationConstants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.ModelPerformance

--- a/src/NLU.DevOps.ModelPerformance/ConfusionMatrix.cs
+++ b/src/NLU.DevOps.ModelPerformance/ConfusionMatrix.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.ModelPerformance

--- a/src/NLU.DevOps.ModelPerformance/ConfusionMatrixResultKind.cs
+++ b/src/NLU.DevOps.ModelPerformance/ConfusionMatrixResultKind.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.ModelPerformance

--- a/src/NLU.DevOps.ModelPerformance/ConfusionMatrixTests.cs
+++ b/src/NLU.DevOps.ModelPerformance/ConfusionMatrixTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.ModelPerformance

--- a/src/NLU.DevOps.ModelPerformance/NLUCompareResults.cs
+++ b/src/NLU.DevOps.ModelPerformance/NLUCompareResults.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.ModelPerformance

--- a/src/NLU.DevOps.ModelPerformance/NLUStatistics.cs
+++ b/src/NLU.DevOps.ModelPerformance/NLUStatistics.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.ModelPerformance

--- a/src/NLU.DevOps.ModelPerformance/Properties/AssemblyInfo.cs
+++ b/src/NLU.DevOps.ModelPerformance/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Runtime.CompilerServices;

--- a/src/NLU.DevOps.ModelPerformance/ScoredEntity.cs
+++ b/src/NLU.DevOps.ModelPerformance/ScoredEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.ModelPerformance

--- a/src/NLU.DevOps.ModelPerformance/ScoredLabeledUtterance.cs
+++ b/src/NLU.DevOps.ModelPerformance/ScoredLabeledUtterance.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.ModelPerformance

--- a/src/NLU.DevOps.ModelPerformance/TestCase.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestCase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.ModelPerformance

--- a/src/NLU.DevOps.ModelPerformance/TestCaseSource.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestCaseSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.ModelPerformance

--- a/src/NLU.DevOps.Models/Entity.cs
+++ b/src/NLU.DevOps.Models/Entity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Models

--- a/src/NLU.DevOps.Models/GlobalSuppressions.cs
+++ b/src/NLU.DevOps.Models/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1040:Avoid empty interfaces", Justification = "The interface is used to identify a set of types at compile time.", Scope = "type", Target = "~T:NLU.DevOps.Models.INLUQuery")]

--- a/src/NLU.DevOps.Models/INLUTestClient.cs
+++ b/src/NLU.DevOps.Models/INLUTestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Models

--- a/src/NLU.DevOps.Models/INLUTrainClient.cs
+++ b/src/NLU.DevOps.Models/INLUTrainClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Models

--- a/src/NLU.DevOps.Models/LabeledUtterance.cs
+++ b/src/NLU.DevOps.Models/LabeledUtterance.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Models

--- a/src/NLU.DevOps.Models/NLUClientExtensions.cs
+++ b/src/NLU.DevOps.Models/NLUClientExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.Models

--- a/src/stylecop.json
+++ b/src/stylecop.json
@@ -9,7 +9,7 @@
   "settings": {
     "documentationRules": {
       "companyName": "Microsoft Corporation",
-      "copyrightText": "Copyright (c) {companyName}. All rights reserved.\nLicensed under the MIT License.",
+      "copyrightText": "Copyright (c) {companyName}.\nLicensed under the MIT License.",
       "documentInternalElements": false,
       "xmlHeader": false
     }


### PR DESCRIPTION
Recent update to Microsoft OSS policy recommends that "All rights reserved." is not included in the copyright header.