### PR TITLE
Adds copyright headers to Python and TypeScript files

### DIFF
--- a/extensions/common/nlu-devops-common/utilities/index.ts
+++ b/extensions/common/nlu-devops-common/utilities/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import * as tl from "azure-pipelines-task-lib/task";
 import * as tr from "azure-pipelines-task-lib/toolrunner";
 import * as path from "path";

--- a/extensions/tasks/NLUCleanV0/index.ts
+++ b/extensions/tasks/NLUCleanV0/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import * as tl from "azure-pipelines-task-lib/task";
 import * as tr from "azure-pipelines-task-lib/toolrunner";
 import { getNLUToolRunner } from "nlu-devops-common/utilities";

--- a/extensions/tasks/NLUTestV0/index.ts
+++ b/extensions/tasks/NLUTestV0/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import * as tl from "azure-pipelines-task-lib/task";
 import * as tr from "azure-pipelines-task-lib/toolrunner";
 import { getNLUToolRunner } from "nlu-devops-common/utilities";

--- a/extensions/tasks/NLUTrainV0/index.ts
+++ b/extensions/tasks/NLUTrainV0/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import * as tl from "azure-pipelines-task-lib/task";
 import * as tr from "azure-pipelines-task-lib/toolrunner";
 import { getNLUToolRunner } from "nlu-devops-common/utilities";

--- a/scripts/compare.py
+++ b/scripts/compare.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import glob
 import re
 import sys


### PR DESCRIPTION
Adds missing copyright headers to AzDO extensions and Azure Pipelines validation script.