### PR TITLE
Runs NUnit tests for compare command in parallel.

### DIFF
--- a/src/NLU.DevOps.ModelPerformance/ConfusionMatrixTests.cs
+++ b/src/NLU.DevOps.ModelPerformance/ConfusionMatrixTests.cs
@@ -6,6 +6,7 @@ namespace NLU.DevOps.ModelPerformance
     using NUnit.Framework;
 
     [TestFixture]
+    [Parallelizable(ParallelScope.All)]
     internal static class ConfusionMatrixTests
     {
         [Test]


### PR DESCRIPTION
The bottleneck for the `compare` command is the exceptions thrown by NUnit for `Assert.Pass` and `Assert.Fail`. Running the tests in parallel will leverage more threads to run the tests. Another thing we can look into if we want to improve this further is to remove the calls to `Assert.Pass` and `Assert.Fail` and instead use expected outputs for unit tests, to remove the need for exception handling. For now, this parallel approach dramatically increases throughput for compare tests.

Fixes #138