### PR TITLE
Adds input for dotnet-nlu tool path

### DIFF
--- a/docs/NLUCleanTask.md
+++ b/docs/NLUCleanTask.md
@@ -15,6 +15,7 @@ Inputs to consider when using the `NLUClean` task:
 - [`workingDirectory`](#workingdirectory)
 - [`nupkgPath`](#nupkgpath)
 - [`toolVersion`](#toolversion)
+- [`toolPath`](#toolPath)
 
 ## Inputs
 
@@ -36,3 +37,7 @@ Specifies the NLU provider to use when deleting the model. Works for `luis`, `lu
 ### `toolVersion`
 
 (Optional) Specifies the version of `dotnet-nlu` to install from the default NuGet repository. You cannot specify both the [`nupkgPath`](#nupkgpath) input and `toolVersion`.
+
+### `toolPath`
+
+(Optional) Specifies the `--tool-path` option to use when installing `dotnet-nlu`. If not provided, the default tool path will be `$(Agent.TempDirectory)/.dotnet`.

--- a/docs/NLUTestTask.md
+++ b/docs/NLUTestTask.md
@@ -33,6 +33,7 @@ Inputs to consider when using the `NLUTest` task:
 - [`workingDirectory`](#workingdirectory)
 - [`nupkgPath`](#nupkgpath)
 - [`toolVersion`](#toolversion)
+- [`toolPath`](#toolPath)
 
 ## Inputs
 
@@ -86,3 +87,7 @@ Specifies the path to the labeled test utterances relative to the [`workingDirec
 ### `toolVersion`
 
 (Optional) Specifies the version of `dotnet-nlu` to install from the default NuGet repository. You cannot specify both the [`nupkgPath`](#nupkgpath) input and `toolVersion`.
+
+### `toolPath`
+
+(Optional) Specifies the `--tool-path` option to use when installing `dotnet-nlu`. If not provided, the default tool path will be `$(Agent.TempDirectory)/.dotnet`.

--- a/docs/NLUTrainTask.md
+++ b/docs/NLUTrainTask.md
@@ -20,6 +20,7 @@ Inputs to consider when using the `NLUClean` task:
 - [`workingDirectory`](#workingdirectory)
 - [`nupkgPath`](#nupkgpath)
 - [`toolVersion`](#toolversion)
+- [`toolPath`](#toolPath)
 
 ## Inputs
 
@@ -49,3 +50,7 @@ Specifies the NLU provider to use when deleting the model. Works for `luis`, `lu
 ### `toolVersion`
 
 (Optional) Specifies the version of `dotnet-nlu` to install from the default NuGet repository. You cannot specify both the [`nupkgPath`](#nupkgpath) input and `toolVersion`.
+
+### `toolPath`
+
+(Optional) Specifies the `--tool-path` option to use when installing `dotnet-nlu`. If not provided, the default tool path will be `$(Agent.TempDirectory)/.dotnet`.

--- a/extensions/common/nlu-devops-common/utilities/index.ts
+++ b/extensions/common/nlu-devops-common/utilities/index.ts
@@ -23,8 +23,9 @@ export async function getNLUToolRunner(): Promise<tr.ToolRunner> {
 
     const nupkgPath = tl.getInput("nupkgPath");
     const toolVersion = tl.getInput("toolVersion");
-    if (result !== 0 || nupkgPath || toolVersion) {
-        const toolPath = path.join(tl.getVariable("Agent.TempDirectory"), ".dotnet");
+    const toolPathInput = tl.getInput("toolPath");
+    if (result !== 0 || nupkgPath || toolVersion || toolPathInput) {
+        const toolPath = toolPathInput || path.join(tl.getVariable("Agent.TempDirectory"), ".dotnet");
         if (result === 0) {
             const dotnetUninstall = tl.tool(dotnetPath)
                 .arg("tool")
@@ -47,7 +48,7 @@ export async function getNLUToolRunner(): Promise<tr.ToolRunner> {
             } as unknown as tr.IExecOptions);
 
             if (uninstallResult !== 0 || isUninstallError) {
-                throw new Error("Failed to uninstall NLU.DevOps.");
+                tl.warning("Failed to uninstall NLU.DevOps.");
             }
         }
 
@@ -61,7 +62,9 @@ export async function getNLUToolRunner(): Promise<tr.ToolRunner> {
         if (nupkgPath) {
             dotnetInstall.arg("--add-source")
                 .arg(nupkgPath);
-        } else if (toolVersion) {
+        }
+
+        if (toolVersion) {
             dotnetInstall.arg("--version")
                 .arg(toolVersion);
         }

--- a/extensions/tasks/NLUCleanV0/task.json
+++ b/extensions/tasks/NLUCleanV0/task.json
@@ -57,6 +57,13 @@
             "label": "Version of dotnet-nlu to install.",
             "helpMarkDown": "Version of dotnet-nlu to install.",
             "required": false
+        },
+        {
+            "name": "toolPath",
+            "type": "string",
+            "label": ".NET Core tool path to install dotnet-nlu.",
+            "helpMarkDown": ".NET Core tool path to install dotnet-nlu.",
+            "required": false
         }
     ],
     "execution": {

--- a/extensions/tasks/NLUTestV0/task.json
+++ b/extensions/tasks/NLUTestV0/task.json
@@ -128,6 +128,13 @@
             "label": "Version of dotnet-nlu to install.",
             "helpMarkDown": "Version of dotnet-nlu to install.",
             "required": false
+        },
+        {
+            "name": "toolPath",
+            "type": "string",
+            "label": ".NET Core tool path to install dotnet-nlu.",
+            "helpMarkDown": ".NET Core tool path to install dotnet-nlu.",
+            "required": false
         }
     ],
     "execution": {

--- a/extensions/tasks/NLUTrainV0/task.json
+++ b/extensions/tasks/NLUTrainV0/task.json
@@ -71,6 +71,13 @@
             "label": "Version of dotnet-nlu to install.",
             "helpMarkDown": "Version of dotnet-nlu to install.",
             "required": false
+        },
+        {
+            "name": "toolPath",
+            "type": "string",
+            "label": ".NET Core tool path to install dotnet-nlu.",
+            "helpMarkDown": ".NET Core tool path to install dotnet-nlu.",
+            "required": false
         }
     ],
     "execution": {


### PR DESCRIPTION
Adds input for .NET Core CLI to use in `--tool-path` option when installing `dotnet-nlu`.

Fixes #151