### PR TITLE
Adds details for compare command options

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,4 +21,6 @@ include:
   - docs/NLUTrainTask.md
   - docs/NLUTestTask.md
   - docs/NLUCleanTask.md
+  - docs/examples/metadata.json
+  - docs/examples/statistics.json
   - extensions/overview.md

--- a/docs/Compare.md
+++ b/docs/Compare.md
@@ -53,6 +53,10 @@ Currently, we do not have any way of overriding the string comparison logic used
 
 The generic utterances model includes an [`entityValue`](GenericUtterances.md#entityvalue) property, which is the semantic or canonical form of the entity. Often times, it's useful enough to know that the NLU model identifies a match for the entity text in the utterance, so we created a separate test case type that compares the expected entity value with the actual entity value, in cases where this property is expected. We assert that the actual entity value contains the JSON subtree specified in the expected entity value.
 
+## Generating JSON test metadata
+
+The compare command by default generates NUnit test output. You can also specify the [`--metadata`](#-m---metadata) flag to generate JSON output, which is currently used by the [`publishNLUResults`](NLUTestTask.md#publishnluresults) input for the [NLUTest](NLUTestTask.md) Azure DevOps task. If the option is used, the CLI command will write a `metadata.json` file containing a JSON array of confusion matrix results and a `statistics.json` file containing a JSON object with counts for confusion matrix results, including results sliced by intent and entity type. The files will be written to the folder provided in the [`--output`](#-o---output) option, or the current working directory if not provided. See the example output for [metadata.json](examples/metadata.json) and [statistics.json](examples/statistics.json) for more details about the schema.
+
 ## Detailed Usage
 
 ### `-e, --expected`
@@ -66,7 +70,13 @@ The path to the result utterances from the `test` command.
 Be sure to use the [`--output`](Test.md#-o---output) option when running the `test` command.
 
 ### `-o, --output-folder`
-(Optional) The path to write the NUnit test results.
+(Optional) The path to write the NUnit test results. If not provided, the current working directory is used.
 
 ### `-l, --label`
 (Optional) A prefix for the test case names, in cases where you may want to publish multiple test runs for different options (e.g., simultaneously test text utterances and speech).
+
+### `-t, --text`
+(Optional) Specifies whether or not confusion matrix results should be generated for text. This is only useful when running end-to-end tests from speech using the [`--speech`](Test.md#--speech) option with the [`test`](Test.md) command.
+
+### `-m, --metadata`
+(Optional) Specified whether confusion matrix metadata should be generated in addition to NUnit test output. See [Generating JSON test metadata](#generating-json-test-metadata) for more details.

--- a/docs/examples/metadata.json
+++ b/docs/examples/metadata.json
@@ -1,0 +1,607 @@
+﻿[
+  {
+    "testName": "TruePositiveIntent('PlayMusic', 'start playing music')",
+    "group": "PlayMusic",
+    "resultKind": "TruePositive",
+    "targetKind": "Intent",
+    "expectedUtterance": {
+      "text": "start playing music",
+      "intent": "PlayMusic"
+    },
+    "actualUtterance": {
+      "score": 0.92854017,
+      "entities": [],
+      "text": "start playing music",
+      "intent": "PlayMusic"
+    },
+    "score": 0.92854017,
+    "because": "Utterances have matching intent.",
+    "categories": [
+      "Intent",
+      "TruePositive"
+    ]
+  },
+  {
+    "testName": "TruePositiveIntent('PlayMusic', 'play music')",
+    "group": "PlayMusic",
+    "resultKind": "TruePositive",
+    "targetKind": "Intent",
+    "expectedUtterance": {
+      "text": "play music",
+      "intent": "PlayMusic"
+    },
+    "actualUtterance": {
+      "score": 0.907853544,
+      "entities": [],
+      "text": "play music",
+      "intent": "PlayMusic"
+    },
+    "score": 0.907853544,
+    "because": "Utterances have matching intent.",
+    "categories": [
+      "Intent",
+      "TruePositive"
+    ]
+  },
+  {
+    "testName": "TruePositiveIntent('PlayMusic', 'listen to hip hop')",
+    "group": "PlayMusic",
+    "resultKind": "TruePositive",
+    "targetKind": "Intent",
+    "expectedUtterance": {
+      "text": "listen to hip hop",
+      "intent": "PlayMusic",
+      "entities": [
+        {
+          "entityType": "Genre",
+          "matchText": "hip hop"
+        }
+      ]
+    },
+    "actualUtterance": {
+      "score": 0.539262056,
+      "entities": [
+        {
+          "score": 0.662749946,
+          "entityType": "Genre",
+          "matchText": "hip"
+        }
+      ],
+      "text": "listen to hip hop",
+      "intent": "PlayMusic"
+    },
+    "score": 0.539262056,
+    "because": "Utterances have matching intent.",
+    "categories": [
+      "Intent",
+      "TruePositive"
+    ]
+  },
+  {
+    "testName": "TruePositiveIntent('PlayMusic', 'listen to jazz')",
+    "group": "PlayMusic",
+    "resultKind": "TruePositive",
+    "targetKind": "Intent",
+    "expectedUtterance": {
+      "text": "listen to jazz",
+      "intent": "PlayMusic",
+      "entities": [
+        {
+          "entityType": "Genre",
+          "matchText": "jazz"
+        }
+      ]
+    },
+    "actualUtterance": {
+      "score": 0.92854017,
+      "entities": [
+        {
+          "score": 0.9545514,
+          "entityType": "Genre",
+          "matchText": "jazz"
+        }
+      ],
+      "text": "listen to jazz",
+      "intent": "PlayMusic"
+    },
+    "score": 0.92854017,
+    "because": "Utterances have matching intent.",
+    "categories": [
+      "Intent",
+      "TruePositive"
+    ]
+  },
+  {
+    "testName": "TruePositiveIntent('PlayMusic', 'play two songs from my playlist')",
+    "group": "PlayMusic",
+    "resultKind": "TruePositive",
+    "targetKind": "Intent",
+    "expectedUtterance": {
+      "text": "play two songs from my playlist",
+      "intent": "PlayMusic",
+      "entities": [
+        {
+          "entityType": "number",
+          "entityValue": "2",
+          "matchText": "two"
+        }
+      ]
+    },
+    "actualUtterance": {
+      "score": 0.4602265,
+      "entities": [
+        {
+          "entityType": "number",
+          "entityValue": "2",
+          "matchText": "two"
+        }
+      ],
+      "text": "play two songs from my playlist",
+      "intent": "PlayMusic"
+    },
+    "score": 0.4602265,
+    "because": "Utterances have matching intent.",
+    "categories": [
+      "Intent",
+      "TruePositive"
+    ]
+  },
+  {
+    "testName": "FalseNegativeIntent('Skip', 'skip this one')",
+    "group": "Skip",
+    "resultKind": "FalseNegative",
+    "targetKind": "Intent",
+    "expectedUtterance": {
+      "text": "skip this one",
+      "intent": "Skip"
+    },
+    "actualUtterance": {
+      "score": 0.449134439,
+      "entities": [],
+      "text": "skip this one",
+      "intent": "None"
+    },
+    "score": 0.449134439,
+    "because": "Actual intent is 'None', expected 'Skip'",
+    "categories": [
+      "Intent",
+      "FalseNegative"
+    ]
+  },
+  {
+    "testName": "TruePositiveIntent('Skip', 'next please')",
+    "group": "Skip",
+    "resultKind": "TruePositive",
+    "targetKind": "Intent",
+    "expectedUtterance": {
+      "text": "next please",
+      "intent": "Skip"
+    },
+    "actualUtterance": {
+      "score": 0.469399869,
+      "entities": [],
+      "text": "next please",
+      "intent": "Skip"
+    },
+    "score": 0.469399869,
+    "because": "Utterances have matching intent.",
+    "categories": [
+      "Intent",
+      "TruePositive"
+    ]
+  },
+  {
+    "testName": "FalseNegativeIntent('Skip', 'go forward')",
+    "group": "Skip",
+    "resultKind": "FalseNegative",
+    "targetKind": "Intent",
+    "expectedUtterance": {
+      "text": "go forward",
+      "intent": "Skip"
+    },
+    "actualUtterance": {
+      "score": 0.463593155,
+      "entities": [],
+      "text": "go forward",
+      "intent": "None"
+    },
+    "score": 0.463593155,
+    "because": "Actual intent is 'None', expected 'Skip'",
+    "categories": [
+      "Intent",
+      "FalseNegative"
+    ]
+  },
+  {
+    "testName": "TrueNegativeIntent('is it cold out')",
+    "resultKind": "TrueNegative",
+    "targetKind": "Intent",
+    "expectedUtterance": {
+      "text": "is it cold out",
+      "intent": "None"
+    },
+    "actualUtterance": {
+      "score": 0.873349249,
+      "entities": [],
+      "text": "is it cold out",
+      "intent": "None"
+    },
+    "score": 0.873349249,
+    "because": "Both intents are 'None'.",
+    "categories": [
+      "Intent",
+      "TrueNegative"
+    ]
+  },
+  {
+    "testName": "TrueNegativeIntent('how many days until Christmas')",
+    "resultKind": "TrueNegative",
+    "targetKind": "Intent",
+    "expectedUtterance": {
+      "text": "how many days until Christmas",
+      "intent": "None"
+    },
+    "actualUtterance": {
+      "score": 0.42890653,
+      "entities": [],
+      "text": "how many days until Christmas",
+      "intent": "None"
+    },
+    "score": 0.42890653,
+    "because": "Both intents are 'None'.",
+    "categories": [
+      "Intent",
+      "TrueNegative"
+    ]
+  },
+  {
+    "testName": "TrueNegativeIntent('what's the weather like')",
+    "resultKind": "TrueNegative",
+    "targetKind": "Intent",
+    "expectedUtterance": {
+      "text": "what's the weather like",
+      "intent": "None"
+    },
+    "actualUtterance": {
+      "score": 0.5407783,
+      "entities": [],
+      "text": "what's the weather like",
+      "intent": "None"
+    },
+    "score": 0.5407783,
+    "because": "Both intents are 'None'.",
+    "categories": [
+      "Intent",
+      "TrueNegative"
+    ]
+  },
+  {
+    "testName": "TrueNegativeEntity('start playing music')",
+    "resultKind": "TrueNegative",
+    "targetKind": "Entity",
+    "expectedUtterance": {
+      "text": "start playing music",
+      "intent": "PlayMusic"
+    },
+    "actualUtterance": {
+      "score": 0.92854017,
+      "entities": [],
+      "text": "start playing music",
+      "intent": "PlayMusic"
+    },
+    "because": "Neither utterances have entities.",
+    "categories": [
+      "Entity",
+      "TrueNegative"
+    ]
+  },
+  {
+    "testName": "TrueNegativeEntity('play music')",
+    "resultKind": "TrueNegative",
+    "targetKind": "Entity",
+    "expectedUtterance": {
+      "text": "play music",
+      "intent": "PlayMusic"
+    },
+    "actualUtterance": {
+      "score": 0.907853544,
+      "entities": [],
+      "text": "play music",
+      "intent": "PlayMusic"
+    },
+    "because": "Neither utterances have entities.",
+    "categories": [
+      "Entity",
+      "TrueNegative"
+    ]
+  },
+  {
+    "testName": "FalseNegativeEntity('Genre', '\"hip hop\"', 'listen to hip hop')",
+    "group": "Genre",
+    "resultKind": "FalseNegative",
+    "targetKind": "Entity",
+    "expectedUtterance": {
+      "text": "listen to hip hop",
+      "intent": "PlayMusic",
+      "entities": [
+        {
+          "entityType": "Genre",
+          "matchText": "hip hop"
+        }
+      ]
+    },
+    "actualUtterance": {
+      "score": 0.539262056,
+      "entities": [
+        {
+          "score": 0.662749946,
+          "entityType": "Genre",
+          "matchText": "hip"
+        }
+      ],
+      "text": "listen to hip hop",
+      "intent": "PlayMusic"
+    },
+    "because": "Actual utterance does not have entity matching 'hip hop'.",
+    "categories": [
+      "Entity",
+      "FalseNegative"
+    ]
+  },
+  {
+    "testName": "FalsePositiveEntity('Genre', '\"hip\"', 'listen to hip hop')",
+    "group": "Genre",
+    "resultKind": "FalsePositive",
+    "targetKind": "Entity",
+    "expectedUtterance": {
+      "text": "listen to hip hop",
+      "intent": "PlayMusic",
+      "entities": [
+        {
+          "entityType": "Genre",
+          "matchText": "hip hop"
+        }
+      ]
+    },
+    "actualUtterance": {
+      "score": 0.539262056,
+      "entities": [
+        {
+          "score": 0.662749946,
+          "entityType": "Genre",
+          "matchText": "hip"
+        }
+      ],
+      "text": "listen to hip hop",
+      "intent": "PlayMusic"
+    },
+    "score": 0.662749946,
+    "because": "Expected utterance does not have entity matching 'hip'.",
+    "categories": [
+      "Entity",
+      "FalsePositive"
+    ]
+  },
+  {
+    "testName": "TruePositiveEntity('Genre', '\"jazz\"', 'listen to jazz')",
+    "group": "Genre",
+    "resultKind": "TruePositive",
+    "targetKind": "Entity",
+    "expectedUtterance": {
+      "text": "listen to jazz",
+      "intent": "PlayMusic",
+      "entities": [
+        {
+          "entityType": "Genre",
+          "matchText": "jazz"
+        }
+      ]
+    },
+    "actualUtterance": {
+      "score": 0.92854017,
+      "entities": [
+        {
+          "score": 0.9545514,
+          "entityType": "Genre",
+          "matchText": "jazz"
+        }
+      ],
+      "text": "listen to jazz",
+      "intent": "PlayMusic"
+    },
+    "score": 0.9545514,
+    "because": "Both utterances have entity 'jazz'.",
+    "categories": [
+      "Entity",
+      "TruePositive"
+    ]
+  },
+  {
+    "testName": "TruePositiveEntity('number', '\"two\"', 'play two songs from my playlist')",
+    "group": "number",
+    "resultKind": "TruePositive",
+    "targetKind": "Entity",
+    "expectedUtterance": {
+      "text": "play two songs from my playlist",
+      "intent": "PlayMusic",
+      "entities": [
+        {
+          "entityType": "number",
+          "entityValue": "2",
+          "matchText": "two"
+        }
+      ]
+    },
+    "actualUtterance": {
+      "score": 0.4602265,
+      "entities": [
+        {
+          "entityType": "number",
+          "entityValue": "2",
+          "matchText": "two"
+        }
+      ],
+      "text": "play two songs from my playlist",
+      "intent": "PlayMusic"
+    },
+    "because": "Both utterances have entity 'two'.",
+    "categories": [
+      "Entity",
+      "TruePositive"
+    ]
+  },
+  {
+    "testName": "TruePositiveEntityValue('number', '\"2\"', 'play two songs from my playlist')",
+    "group": "number",
+    "resultKind": "TruePositive",
+    "targetKind": "EntityValue",
+    "expectedUtterance": {
+      "text": "play two songs from my playlist",
+      "intent": "PlayMusic",
+      "entities": [
+        {
+          "entityType": "number",
+          "entityValue": "2",
+          "matchText": "two"
+        }
+      ]
+    },
+    "actualUtterance": {
+      "score": 0.4602265,
+      "entities": [
+        {
+          "entityType": "number",
+          "entityValue": "2",
+          "matchText": "two"
+        }
+      ],
+      "text": "play two songs from my playlist",
+      "intent": "PlayMusic"
+    },
+    "because": "Both utterances have entity value '\"2\"'.",
+    "categories": [
+      "Entity",
+      "TruePositive"
+    ]
+  },
+  {
+    "testName": "TrueNegativeEntity('skip this one')",
+    "resultKind": "TrueNegative",
+    "targetKind": "Entity",
+    "expectedUtterance": {
+      "text": "skip this one",
+      "intent": "Skip"
+    },
+    "actualUtterance": {
+      "score": 0.449134439,
+      "entities": [],
+      "text": "skip this one",
+      "intent": "None"
+    },
+    "because": "Neither utterances have entities.",
+    "categories": [
+      "Entity",
+      "TrueNegative"
+    ]
+  },
+  {
+    "testName": "TrueNegativeEntity('next please')",
+    "resultKind": "TrueNegative",
+    "targetKind": "Entity",
+    "expectedUtterance": {
+      "text": "next please",
+      "intent": "Skip"
+    },
+    "actualUtterance": {
+      "score": 0.469399869,
+      "entities": [],
+      "text": "next please",
+      "intent": "Skip"
+    },
+    "because": "Neither utterances have entities.",
+    "categories": [
+      "Entity",
+      "TrueNegative"
+    ]
+  },
+  {
+    "testName": "TrueNegativeEntity('go forward')",
+    "resultKind": "TrueNegative",
+    "targetKind": "Entity",
+    "expectedUtterance": {
+      "text": "go forward",
+      "intent": "Skip"
+    },
+    "actualUtterance": {
+      "score": 0.463593155,
+      "entities": [],
+      "text": "go forward",
+      "intent": "None"
+    },
+    "because": "Neither utterances have entities.",
+    "categories": [
+      "Entity",
+      "TrueNegative"
+    ]
+  },
+  {
+    "testName": "TrueNegativeEntity('is it cold out')",
+    "resultKind": "TrueNegative",
+    "targetKind": "Entity",
+    "expectedUtterance": {
+      "text": "is it cold out",
+      "intent": "None"
+    },
+    "actualUtterance": {
+      "score": 0.873349249,
+      "entities": [],
+      "text": "is it cold out",
+      "intent": "None"
+    },
+    "because": "Neither utterances have entities.",
+    "categories": [
+      "Entity",
+      "TrueNegative"
+    ]
+  },
+  {
+    "testName": "TrueNegativeEntity('how many days until Christmas')",
+    "resultKind": "TrueNegative",
+    "targetKind": "Entity",
+    "expectedUtterance": {
+      "text": "how many days until Christmas",
+      "intent": "None"
+    },
+    "actualUtterance": {
+      "score": 0.42890653,
+      "entities": [],
+      "text": "how many days until Christmas",
+      "intent": "None"
+    },
+    "because": "Neither utterances have entities.",
+    "categories": [
+      "Entity",
+      "TrueNegative"
+    ]
+  },
+  {
+    "testName": "TrueNegativeEntity('what's the weather like')",
+    "resultKind": "TrueNegative",
+    "targetKind": "Entity",
+    "expectedUtterance": {
+      "text": "what's the weather like",
+      "intent": "None"
+    },
+    "actualUtterance": {
+      "score": 0.5407783,
+      "entities": [],
+      "text": "what's the weather like",
+      "intent": "None"
+    },
+    "because": "Neither utterances have entities.",
+    "categories": [
+      "Entity",
+      "TrueNegative"
+    ]
+  }
+]

--- a/docs/examples/statistics.json
+++ b/docs/examples/statistics.json
@@ -1,0 +1,41 @@
+﻿{
+  "text": {},
+  "intent": {
+    "truePositive": 6,
+    "trueNegative": 3,
+    "falseNegative": 2
+  },
+  "entity": {
+    "truePositive": 2,
+    "trueNegative": 8,
+    "falsePositive": 1,
+    "falseNegative": 1
+  },
+  "entityValue": {
+    "truePositive": 1
+  },
+  "byIntent": {
+    "playMusic": {
+      "truePositive": 5
+    },
+    "skip": {
+      "truePositive": 1,
+      "falseNegative": 2
+    }
+  },
+  "byEntityType": {
+    "genre": {
+      "truePositive": 1,
+      "falsePositive": 1,
+      "falseNegative": 1
+    },
+    "number": {
+      "truePositive": 1
+    }
+  },
+  "byEntityValueType": {
+    "number": {
+      "truePositive": 1
+    }
+  }
+}

--- a/src/NLU.DevOps.CommandLine/Compare/CompareOptions.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareOptions.cs
@@ -17,7 +17,7 @@ namespace NLU.DevOps.CommandLine.Compare
         [Option('l', "label", HelpText = "Label for differentiating comparison runs.", Required = false)]
         public string TestLabel { get; set; }
 
-        [Option('m', "metadata", HelpText = "Return test case metadata as opposed to NUnit test results.", Required = false)]
+        [Option('m', "metadata", HelpText = "Return test case metadata in addition to NUnit test results.", Required = false)]
         public bool Metadata { get; set; }
 
         [Option('t', "text", HelpText = "Run text comparison test cases.", Required = false)]


### PR DESCRIPTION
Adds details for the recently added `-t, --text` and `-m, --metadata` options for the `compare` command.

Fixes #158