### PR TITLE
Adds .json extension to NLUTest pipeline attachments

### DIFF
--- a/extensions/tasks/NLUTestV0/__tests__/runTask.spec.ts
+++ b/extensions/tasks/NLUTestV0/__tests__/runTask.spec.ts
@@ -294,7 +294,9 @@ describe("NLUTest", () => {
         expect(writeFileSyncStub.calledWith(allStatisticsPath, "[]")).to.be.ok;
 
         // assert adds attachment
-        expect(addAttachmentStub.calledWith("nlu.devops", "statistics", allStatisticsPath)).to.be.ok;
+        const metadataPath = path.join(".nlu", "text", "metadata.json");
+        expect(addAttachmentStub.calledWith("nlu.devops", "metadata.json", metadataPath)).to.be.ok;
+        expect(addAttachmentStub.calledWith("nlu.devops", "statistics.json", allStatisticsPath)).to.be.ok;
     });
 
     it("publishes statistics if master build", async () => {

--- a/extensions/tasks/NLUTestV0/runTask.ts
+++ b/extensions/tasks/NLUTestV0/runTask.ts
@@ -157,14 +157,14 @@ async function publishNLUResults() {
     const compareOutput = getCompareOutputPath() as string;
 
     console.log("Publishing metadata attachment for NLU results.");
-    tl.addAttachment("nlu.devops", "metadata", path.join(compareOutput, `metadata.json`));
+    tl.addAttachment("nlu.devops", "metadata.json", path.join(compareOutput, `metadata.json`));
 
     console.log("Publishing statistics attachment for NLU results.");
     const statisticsPath = path.join(compareOutput, "statistics.json");
     const allStatisticsPath = path.join(compareOutput, "allStatistics.json");
     const buildStatistics = await getBuildStatistics(statisticsPath);
     fs.writeFileSync(allStatisticsPath, JSON.stringify(buildStatistics, null, 2));
-    tl.addAttachment("nlu.devops", "statistics", allStatisticsPath);
+    tl.addAttachment("nlu.devops", "statistics.json", allStatisticsPath);
 
     if (tl.getVariable("Build.SourceBranch") === "refs/heads/master") {
         const publishData = {


### PR DESCRIPTION
This is primarily for debugging purposes, but also makes it clear that the attachment files contain JSON content.

Fixes #161