### PR TITLE
Adds entity value example to E2E tests

### DIFF
--- a/models/settings.luis.json
+++ b/models/settings.luis.json
@@ -1,5 +1,13 @@
 {
+  "prebuiltEntityTypes": {
+    "number": "number"
+  },
   "appTemplate": {
+    "prebuiltEntities": [
+      {
+        "name": "number"
+      }
+    ],
     "intents": [
       {
         "name": "Skip",

--- a/models/tests.json
+++ b/models/tests.json
@@ -30,6 +30,18 @@
     ]
   },
   {
+    "text": "play two songs from my playlist",
+    "intent": "PlayMusic",
+    "entities": [
+      {
+        "entityType": "number",
+        "matchText": "two",
+        "matchIndex": 0,
+        "entityValue": "2"
+      }
+    ]
+  },
+  {
     "text": "skip this one",
     "intent": "Skip"
   },


### PR DESCRIPTION
Adds example of an entity value that should be recognized, and also updates the LUIS model training so the entity value will be recognized correctly.

Fixes #160