### PR TITLE
Reduces verbosity of confusion matrix JSON

### DIFF
--- a/src/NLU.DevOps.CommandLine/Serializer.cs
+++ b/src/NLU.DevOps.CommandLine/Serializer.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 namespace NLU.DevOps.CommandLine
 {
     using System.IO;
     using System.Text;
     using Core;
+    using ModelPerformance;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
     using Newtonsoft.Json.Serialization;
@@ -35,6 +37,7 @@ namespace NLU.DevOps.CommandLine
             serializer.ContractResolver = new CamelCasePropertyNamesContractResolver();
             serializer.DefaultValueHandling = DefaultValueHandling.Ignore;
             serializer.Converters.Add(new StringEnumConverter());
+            serializer.Converters.Add(new ConfusionMatrixConverter());
             serializer.Formatting = Formatting.Indented;
             using (var textWriter = new StreamWriter(stream, Encoding.UTF8, 4096, true))
             {

--- a/src/NLU.DevOps.CommandLine/ServiceResolver.cs
+++ b/src/NLU.DevOps.CommandLine/ServiceResolver.cs
@@ -7,8 +7,6 @@ namespace NLU.DevOps.CommandLine
     using System.Composition.Hosting;
     using System.IO;
     using System.Linq;
-    using System.Reflection;
-    using System.Runtime.Loader;
     using McMaster.NETCore.Plugins;
 
     internal static class ServiceResolver

--- a/src/NLU.DevOps.ModelPerformance.Tests/ConfusionMatrixConverterTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/ConfusionMatrixConverterTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.ModelPerformance.Tests
+{
+    using FluentAssertions;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+    using NUnit.Framework;
+
+    [TestFixture]
+    internal static class ConfusionMatrixConverterTests
+    {
+        [Test]
+        public static void WritesNullValue()
+        {
+            var converter = new ConfusionMatrixConverter();
+            var serializer = JsonSerializer.CreateDefault();
+            serializer.Converters.Add(converter);
+            var json = JToken.FromObject(new ConfusionMatrixContainer(), serializer);
+            json.Type.Should().Be(JTokenType.Object);
+            json.As<JObject>().ContainsKey("Data").Should().BeTrue();
+            json["Data"].Type.Should().Be(JTokenType.Null);
+        }
+
+        [Test]
+        public static void WritesValueAsArray()
+        {
+            var value = new ConfusionMatrix(42, 7, 1, 0);
+            var converter = new ConfusionMatrixConverter();
+            var serializer = JsonSerializer.CreateDefault();
+            serializer.Converters.Add(converter);
+            var json = JToken.FromObject(value, serializer);
+            json.Type.Should().Be(JTokenType.Array);
+            json.As<JArray>().Count.Should().Be(4);
+            json.Value<int>(0).Should().Be(42);
+            json.Value<int>(1).Should().Be(7);
+            json.Value<int>(2).Should().Be(1);
+            json.Value<int>(3).Should().Be(0);
+        }
+
+        private class ConfusionMatrixContainer
+        {
+            public ConfusionMatrix Data { get; set; }
+        }
+    }
+}

--- a/src/NLU.DevOps.ModelPerformance/ConfusionMatrixConverter.cs
+++ b/src/NLU.DevOps.ModelPerformance/ConfusionMatrixConverter.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.ModelPerformance
+{
+    using System;
+    using System.Diagnostics;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// JSON converter for <see cref="ConfusionMatrix"/>.
+    /// </summary>
+    public class ConfusionMatrixConverter : JsonConverter<ConfusionMatrix>
+    {
+        /// <inheritdoc />
+        public override bool CanRead => false;
+
+        /// <inheritdoc />
+        public override ConfusionMatrix ReadJson(JsonReader reader, Type objectType, ConfusionMatrix existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override void WriteJson(JsonWriter writer, ConfusionMatrix value, JsonSerializer serializer)
+        {
+            Debug.Assert(value != null, "Newtonsoft.Json will not call this method if the value is null.");
+            writer.WriteStartArray();
+            writer.WriteValue(value.TruePositive);
+            writer.WriteValue(value.TrueNegative);
+            writer.WriteValue(value.FalsePositive);
+            writer.WriteValue(value.FalseNegative);
+            writer.WriteEndArray();
+        }
+    }
+}


### PR DESCRIPTION
Rather than using a JSON object like:
```json
{
  "truePositive": 42,
  "trueNegative": 7,
  "falsePositive": 1,
  "falseNegative": 0
}
```

This change uses a JSON array for a concise representation of confusion matrices, i.e., `[ 42, 7, 1, 0 ]`.

Fixes #159