### PR TITLE
Adds JSON formatting to statistics attachment

### DIFF
--- a/extensions/tasks/NLUTestV0/runTask.ts
+++ b/extensions/tasks/NLUTestV0/runTask.ts
@@ -163,7 +163,7 @@ async function publishNLUResults() {
     const statisticsPath = path.join(compareOutput, "statistics.json");
     const allStatisticsPath = path.join(compareOutput, "allStatistics.json");
     const buildStatistics = await getBuildStatistics(statisticsPath);
-    fs.writeFileSync(allStatisticsPath, JSON.stringify(buildStatistics));
+    fs.writeFileSync(allStatisticsPath, JSON.stringify(buildStatistics, null, 2));
     tl.addAttachment("nlu.devops", "statistics", allStatisticsPath);
 
     if (tl.getVariable("Build.SourceBranch") === "refs/heads/master") {


### PR DESCRIPTION
When we aggregate and write `statistics.json` from the `NLUTest` task, this change ensures the `JSON.stringify` call adds indentation and whitespace to the results.

Fixes #167