### PR TITLE
Removes workaround for mocking fs.writeFileSync

### DIFF
--- a/extensions/package.json
+++ b/extensions/package.json
@@ -15,8 +15,8 @@
         "postbuild": "npm run package",
         "package": "tfx extension create --rev-version --manifest-globs",
         "clean": "rimraf ./*.vsix && rimraf ./*.tgz",
-        "testCommon": "npm-recursive-install --rootDir=common && ts-mocha \"common/**/__tests__/**/*.ts\" -p common/tsconfig.json",
-        "testTasks": "npm-recursive-install --rootDir=tasks && ts-mocha \"tasks/**/__tests__/**/*.ts\" -p tasks/tsconfig.json", 
+        "testCommon": "npm-recursive-install --rootDir=common && mocha -r ts-node/register common/**/__tests__/**/*.ts",
+        "testTasks": "npm-recursive-install --rootDir=tasks && mocha -r ts-node/register tasks/**/__tests__/**/*.ts",
         "test": "npm run testCommon && npm run buildCommon && npm run testTasks"
     },
     "repository": {
@@ -37,9 +37,10 @@
         "sinon": "^7.4.1",
         "tfx-cli": "^0.7.8",
         "ts-mocha": "^6.0.0",
+        "ts-mock-imports": "^1.2.6",
+        "ts-node": "^8.3.0",
         "tslint": "^5.18.0",
         "tslint-no-unused-expression-chai": "^0.1.4",
-        "ts-mock-imports": "^1.2.6",
         "typescript": "^3.5.3"
     }
 }

--- a/extensions/tasks/NLUTestV0/__tests__/runTask.spec.ts
+++ b/extensions/tasks/NLUTestV0/__tests__/runTask.spec.ts
@@ -9,16 +9,13 @@ global[taskLoadedKey] = true;
 import * as tl from "azure-pipelines-task-lib/task";
 import * as tr from "azure-pipelines-task-lib/toolrunner";
 import { expect } from "chai";
+import * as fs from "fs";
 import * as utilities from "nlu-devops-common/utilities";
 import * as path from "path";
 import * as sinon from "sinon";
 import { ImportMock, MockManager } from "ts-mock-imports";
 import * as artifacts from "../artifacts";
 import { run } from "../runTask";
-
-// Import rule disabled to enable mocking
-// tslint:disable-next-line:no-var-requires
-const fs = require("fs");
 
 describe("NLUTest", () => {
     let getInputStub: sinon.SinonStub<any[], any>;

--- a/extensions/tasks/NLUTestV0/artifacts.ts
+++ b/extensions/tasks/NLUTestV0/artifacts.ts
@@ -5,13 +5,13 @@ import { IBuildApi } from "azure-devops-node-api/BuildApi";
 import { BuildResult, BuildStatus } from "azure-devops-node-api/interfaces/BuildInterfaces";
 import { getHandlerFromToken, WebApi } from "azure-devops-node-api/WebApi";
 import * as tl from "azure-pipelines-task-lib/task";
-import * as fs from "fs";
+import { readFileSync } from "fs";
 import * as path from "path";
 import * as unzip from "unzip-stream";
 
 export async function getBuildStatistics(statisticsPath: string): Promise<Array<{ id: string, statistics: any }>> {
     const buildStatistics = await getPreviousBuildStatistics();
-    const statisticsData = fs.readFileSync(statisticsPath).toString().trim();
+    const statisticsData = readFileSync(statisticsPath).toString().trim();
     const statistics = JSON.parse(statisticsData);
     buildStatistics.push({
         id: tl.getVariable("Build.BuildId"),
@@ -72,7 +72,7 @@ async function downloadStatisticsArtifact(projectId: string, client: IBuildApi, 
         const id = `${buildId}`;
         const unzipPath = path.join(tl.getVariable("Agent.TempDirectory"), "artifacts", id);
         await new Promise((resolve, _) => artifactStream.pipe(unzip.Extract({ path: unzipPath })).on("close", resolve));
-        const statisticsData = fs.readFileSync(path.join(unzipPath, "statistics", "statistics.json")).toString().trim();
+        const statisticsData = readFileSync(path.join(unzipPath, "statistics", "statistics.json")).toString().trim();
         const statistics = JSON.parse(statisticsData);
         return { id, statistics };
 }

--- a/extensions/tasks/NLUTestV0/runTask.ts
+++ b/extensions/tasks/NLUTestV0/runTask.ts
@@ -3,13 +3,10 @@
 
 import * as tl from "azure-pipelines-task-lib/task";
 import * as tr from "azure-pipelines-task-lib/toolrunner";
+import { writeFileSync } from "fs";
 import { getNLUToolRunner } from "nlu-devops-common/utilities";
 import * as path from "path";
 import { getBuildStatistics } from "./artifacts";
-
-// Import rule disabled to enable mocking
-// tslint:disable-next-line:no-var-requires
-const fs = require("fs");
 
 export async function run() {
     try {
@@ -163,7 +160,7 @@ async function publishNLUResults() {
     const statisticsPath = path.join(compareOutput, "statistics.json");
     const allStatisticsPath = path.join(compareOutput, "allStatistics.json");
     const buildStatistics = await getBuildStatistics(statisticsPath);
-    fs.writeFileSync(allStatisticsPath, JSON.stringify(buildStatistics, null, 2));
+    writeFileSync(allStatisticsPath, JSON.stringify(buildStatistics, null, 2));
     tl.addAttachment("nlu.devops", "statistics.json", allStatisticsPath);
 
     if (tl.getVariable("Build.SourceBranch") === "refs/heads/master") {


### PR DESCRIPTION
We had previously worked around a limitation of `ts-mock-imports` by doing a direct require of the `fs` module from Node. This change removes the workaround by importing `writeFileSync` in an import statement instead of importing `*` from `fs`.

Fixes #170