### PR TITLE
Resolves LUIS v2 entities with roles

### DIFF
--- a/docs/LuisModelConfiguration.md
+++ b/docs/LuisModelConfiguration.md
@@ -138,6 +138,48 @@ To configure the `Recipient` entity type as a LUIS prebuilt entity, the [`--mode
 
 During testing, to ensure that the entity types returned from LUIS are remapped back to the user-supplied entity type name, you must also supply the LUIS settings file above to the `test` command via the [`--model-settings`](Test.md#-m---model-settings) option.
 
+### Training entities with roles
+
+In order to label a [LUIS role](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-concept-roles) on an entity in a generic utterance, you can label the [`entityType`](GenericUtterances.md#entityType) using the role name, but you must also map each role name to the entity type in the [`roles`] object in the LUIS model settings. For example, if you have the following utterance with a role-labeled entity:
+
+```json
+{
+  "text": "play two songs from my play list",
+  "intent": "PlayMusic",
+  "entities": [
+    {
+      "matchText": "two",
+      "entityType": "songCount"
+    }
+  ]
+}
+```
+
+Then you can also map the `songCount` role to the `number` defined entity type (or any other LUIS entity type supporting roles) using the following configuration in the model settings:
+
+```json
+{
+  "roles": {
+    "songCount": "number"
+  }
+}
+```
+
+This will result in the labeled entity being sent to LUIS as follows:
+
+```json
+{
+  "startPos": 5,
+  "endPos": 7,
+  "entity": "number",
+  "role": "songCount"
+}
+```
+
+### Testing entities with roles
+
+In both LUIS v2 and v3, if a role is recognized, the [`entityType`](GenericUtterances.md#entityType) property will use the role name instead of the entity type.
+
 ## Configuring builtin intents
 
 To configure a builtin intent for LUIS, add the following to the `appTemplate` property of your LUIS settings JSON (i.e., the [`--model-settings`](Train.md#-m---model-settings) file supplied to the `train` command):

--- a/models/settings.luis.json
+++ b/models/settings.luis.json
@@ -1,11 +1,14 @@
 {
-  "prebuiltEntityTypes": {
-    "number": "number"
+  "roles": {
+    "songCount": "number"
   },
   "appTemplate": {
     "prebuiltEntities": [
       {
-        "name": "number"
+        "name": "number",
+        "roles": [
+          "songCount"
+        ]
       }
     ],
     "intents": [

--- a/models/tests.json
+++ b/models/tests.json
@@ -30,14 +30,14 @@
     ]
   },
   {
-    "text": "play two songs from my playlist",
+    "text": "play five songs from my playlist",
     "intent": "PlayMusic",
     "entities": [
       {
-        "entityType": "number",
-        "matchText": "two",
+        "entityType": "songCount",
+        "matchText": "five",
         "matchIndex": 0,
-        "entityValue": "2"
+        "entityValue": "5"
       }
     ]
   },

--- a/models/utterances.json
+++ b/models/utterances.json
@@ -26,6 +26,17 @@
     ]
   },
   {
+    "text": "play two songs from my playlist",
+    "intent": "PlayMusic",
+    "entities": [
+      {
+        "entityType": "songCount",
+        "matchText": "two",
+        "matchIndex": 0
+      }
+    ]
+  },
+  {
     "text": "start playing music",
     "intent": "PlayMusic"
   },
@@ -39,6 +50,10 @@
   },
   {
     "text": "call the pizza place",
+    "intent": "None"
+  },
+  {
+    "text": "how long until thanksgiving",
     "intent": "None"
   }
 ]

--- a/src/CommonNuget.props
+++ b/src/CommonNuget.props
@@ -8,6 +8,6 @@
     <PackageProjectUrl>https://github.com/Microsoft/NLU.DevOps</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Microsoft/NLU.DevOps.git</RepositoryUrl>
     <Copyright>© Microsoft Corporation.</Copyright>
-    <Version>0.4.2</Version>
+    <Version>0.5.0</Version>
   </PropertyGroup>
 </Project>

--- a/src/NLU.DevOps.Luis.Shared/JSONEntityWithRole.cs
+++ b/src/NLU.DevOps.Luis.Shared/JSONEntityWithRole.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.Luis
+{
+    using Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring.Models;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// <see cref="JSONEntity"/> with additional role property.
+    /// </summary>
+    public class JSONEntityWithRole : JSONEntity
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JSONEntityWithRole"/> class.
+        /// </summary>
+        /// <param name="startPos">Start position of the entity.</param>
+        /// <param name="endPos">End position of the entity.</param>
+        /// <param name="entity">Entity type.</param>
+        /// <param name="role">Entity role.</param>
+        public JSONEntityWithRole(int startPos, int endPos, string entity, string role)
+            : base(startPos, endPos, entity)
+        {
+            this.Role = role;
+        }
+
+        /// <summary>
+        /// Gets or sets the role for the entity.
+        /// </summary>
+        /// <remarks>
+        /// Do not change the setter to private, as this will prevent the
+        /// LUIS client serializer from serializing this property.
+        /// </remarks>
+        [JsonProperty("role")]
+        public string Role { get; set; }
+    }
+}

--- a/src/NLU.DevOps.Luis.Shared/LabeledUtteranceExtensions.cs
+++ b/src/NLU.DevOps.Luis.Shared/LabeledUtteranceExtensions.cs
@@ -4,22 +4,27 @@
 namespace NLU.DevOps.Luis
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring.Models;
     using Models;
 
     internal static class LabeledUtteranceExtensions
     {
-        public static JSONUtterance ToJSONUtterance(this Models.LabeledUtterance utterance, IReadOnlyDictionary<string, string> prebuiltEntityTypes)
+        public static JSONUtterance ToJSONUtterance(this Models.LabeledUtterance utterance, LuisSettings luisSettings)
         {
             JSONEntity toJSONEntity(Entity entity)
             {
-                var entityType = prebuiltEntityTypes.TryGetValue(entity.EntityType, out var builtinType)
+                var startPos = entity.StartCharIndexInText(utterance.Text);
+                var endPos = startPos + entity.MatchText.Length - 1;
+                if (luisSettings.Roles.TryGetValue(entity.EntityType, out var entityType))
+                {
+                    return new JSONEntityWithRole(startPos, endPos, entityType, entity.EntityType);
+                }
+
+                entityType = luisSettings.PrebuiltEntityTypes.TryGetValue(entity.EntityType, out var builtinType)
                     ? builtinType
                     : entity.EntityType;
-                var startPos = entity.StartCharIndexInText(utterance.Text);
-                return new JSONEntity(startPos, startPos + entity.MatchText.Length - 1, entityType);
+                return new JSONEntity(startPos, endPos, entityType);
             }
 
             return new JSONUtterance(

--- a/src/NLU.DevOps.Luis.Shared/LuisNLUTrainClient.cs
+++ b/src/NLU.DevOps.Luis.Shared/LuisNLUTrainClient.cs
@@ -9,6 +9,7 @@ namespace NLU.DevOps.Luis
     using System.Threading;
     using System.Threading.Tasks;
     using Logging;
+    using Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring;
     using Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring.Models;
     using Microsoft.Extensions.Logging;
     using Models;
@@ -129,7 +130,7 @@ namespace NLU.DevOps.Luis
             // Add utterances to model
             luisApp.Utterances = luisApp.Utterances ?? new List<JSONUtterance>();
             utterances
-                .Select(utterance => utterance.ToJSONUtterance(this.LuisSettings.PrebuiltEntityTypes))
+                .Select(utterance => utterance.ToJSONUtterance(this.LuisSettings))
                 .ToList()
                 .ForEach(luisApp.Utterances.Add);
 

--- a/src/NLU.DevOps.Luis.Shared/LuisSettings.cs
+++ b/src/NLU.DevOps.Luis.Shared/LuisSettings.cs
@@ -18,7 +18,7 @@ namespace NLU.DevOps.Luis
         /// Initializes a new instance of the <see cref="LuisSettings"/> class.
         /// </summary>
         public LuisSettings()
-            : this(null, null)
+            : this(null, null, null)
         {
         }
 
@@ -27,7 +27,7 @@ namespace NLU.DevOps.Luis
         /// </summary>
         /// <param name="appTemplate">App template.</param>
         public LuisSettings(LuisApp appTemplate)
-            : this(appTemplate, null)
+            : this(appTemplate, null, null)
         {
         }
 
@@ -36,7 +36,7 @@ namespace NLU.DevOps.Luis
         /// </summary>
         /// <param name="prebuiltEntityTypes">Prebuilt entity types.</param>
         public LuisSettings(IReadOnlyDictionary<string, string> prebuiltEntityTypes)
-            : this(null, prebuiltEntityTypes)
+            : this(null, prebuiltEntityTypes, null)
         {
         }
 
@@ -45,11 +45,13 @@ namespace NLU.DevOps.Luis
         /// </summary>
         /// <param name="appTemplate">App template.</param>
         /// <param name="prebuiltEntityTypes">Prebuilt entity types.</param>
+        /// <param name="roles">Role mappings.</param>
         [JsonConstructor]
-        public LuisSettings(LuisApp appTemplate, IReadOnlyDictionary<string, string> prebuiltEntityTypes)
+        public LuisSettings(LuisApp appTemplate, IReadOnlyDictionary<string, string> prebuiltEntityTypes, IReadOnlyDictionary<string, string> roles)
         {
             this.AppTemplate = appTemplate ?? new LuisApp();
             this.PrebuiltEntityTypes = prebuiltEntityTypes ?? new Dictionary<string, string>();
+            this.Roles = roles ?? new Dictionary<string, string>();
         }
 
         /// <summary>
@@ -63,6 +65,11 @@ namespace NLU.DevOps.Luis
         public IReadOnlyDictionary<string, string> PrebuiltEntityTypes { get; }
 
         /// <summary>
+        /// Gets the role mappings.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> Roles { get; }
+
+        /// <summary>
         /// Converts a <see cref="JObject"/> to <see cref="LuisSettings"/>.
         /// </summary>
         /// <param name="settings">Settings JSON.</param>
@@ -74,7 +81,7 @@ namespace NLU.DevOps.Luis
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            if (settings.ContainsKey("appTemplate") || settings.ContainsKey("prebuiltEntityTypes"))
+            if (settings.ContainsKey("appTemplate") || settings.ContainsKey("prebuiltEntityTypes") || settings.ContainsKey("roles"))
             {
                 return settings.ToObject<LuisSettings>();
             }

--- a/src/NLU.DevOps.Luis.Shared/NLU.DevOps.Luis.Shared.projitems
+++ b/src/NLU.DevOps.Luis.Shared/NLU.DevOps.Luis.Shared.projitems
@@ -20,5 +20,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)LuisConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ILuisConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestLuisConfiguration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)JSONEntityWithRole.cs" />
   </ItemGroup>
 </Project>

--- a/src/NLU.DevOps.Luis.Tests.Shared/LuisSettingsTests.cs
+++ b/src/NLU.DevOps.Luis.Tests.Shared/LuisSettingsTests.cs
@@ -32,6 +32,18 @@ namespace NLU.DevOps.Luis.Tests
         }
 
         [Test]
+        public static void ParsesRoles()
+        {
+            var settings = LuisSettings.FromJson(new JObject
+            {
+                { "roles", new JObject { { "foo", "bar" } } },
+            });
+
+            settings.AppTemplate.Name.Should().BeNull();
+            settings.Roles.Should().Contain(new KeyValuePair<string, string>("foo", "bar"));
+        }
+
+        [Test]
         public static void ParsesAppTemplate()
         {
             var settings = LuisSettings.FromJson(new JObject

--- a/src/NLU.DevOps.Luis.Tests/LuisNLUTestClientTests.cs
+++ b/src/NLU.DevOps.Luis.Tests/LuisNLUTestClientTests.cs
@@ -390,9 +390,47 @@ namespace NLU.DevOps.Luis.Tests
             }
         }
 
+        [Test]
+        public static async Task WithRole()
+        {
+            var test = "the quick brown fox jumped over the lazy dog";
+
+            var builder = new LuisNLUTestClientBuilder();
+            builder.LuisTestClientMock
+                .Setup(luis => luis.QueryAsync(
+                    It.Is<string>(query => query == test),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult(new LuisResult
+                {
+                    Query = test,
+                    TopScoringIntent = new IntentModel { Intent = "intent" },
+                    Entities = new[]
+                    {
+                        new EntityModel
+                        {
+                            Entity = "the",
+                            Type = "type",
+                            StartIndex = 32,
+                            EndIndex = 34,
+                            AdditionalProperties = new Dictionary<string, object>
+                            {
+                                { "role", "role" },
+                            },
+                        },
+                    },
+                }));
+
+            using (var luis = builder.Build())
+            {
+                var result = await luis.TestAsync(test).ConfigureAwait(false);
+                result.Entities.Count.Should().Be(1);
+                result.Entities[0].EntityType.Should().Be("role");
+            }
+        }
+
         private class LuisNLUTestClientBuilder
         {
-            public LuisSettings LuisSettings { get; set; } = new LuisSettings(null, null);
+            public LuisSettings LuisSettings { get; set; } = new LuisSettings(null, null, null);
 
             public Mock<ILuisTestClient> LuisTestClientMock { get; } = new Mock<ILuisTestClient>();
 

--- a/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
@@ -96,7 +96,16 @@ namespace NLU.DevOps.Luis
             Entity getEntity(EntityModel entity)
             {
                 var entityType = entity.Type;
-                if (entityType != null && mappedTypes.TryGetValue(entityType, out var mappedType))
+                var hasRole = false;
+                if (entity.AdditionalProperties != null &&
+                    entity.AdditionalProperties.TryGetValue("role", out var roleValue) &&
+                    roleValue is string role)
+                {
+                    entityType = role;
+                    hasRole = true;
+                }
+
+                if (!hasRole && entityType != null && mappedTypes.TryGetValue(entityType, out var mappedType))
                 {
                     entityType = mappedType;
                 }

--- a/src/NLU.DevOps.Models/NLU.DevOps.Models.csproj
+++ b/src/NLU.DevOps.Models/NLU.DevOps.Models.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CodeAnalysis.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>0.4.0</AssemblyVersion>
+    <AssemblyVersion>0.5.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">


### PR DESCRIPTION
LUIS v3 sets the entity type for entities with roles to the role name. This change adds a similar resolution mechanism to LUIS v2, resolving entities with a "role" property to use the role for the entity type. This change also supports training LUIS v2 and v3 models with entities labeled with roles by adding the "roles" property to the `LuisSettings` supplied with the `--model-settings` CLI option.

Fixes #166