### PR TITLE
Sets default visibility of AzDO extension to false

### DIFF
--- a/extensions/vss-extension.json
+++ b/extensions/vss-extension.json
@@ -5,7 +5,7 @@
     "name": "NLU.DevOps",
     "description": "A collection of tasks and results tabs for NLU.DevOps",
     "publisher": "NLUDevOps",
-    "public": true,
+    "public": false,
     "icons": {
         "default": "images/icon.png"
     },


### PR DESCRIPTION
We switch the AzDO extension visibility to public in the release pipeline, so for developers looking to build the extension privately and test in their own Visual Studio Marketplace organization, it's better to set the default visibility to false.

Fixes #177