### PR TITLE
Adds utterance ID to each test case

### DIFF
--- a/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
@@ -33,7 +33,7 @@ namespace NLU.DevOps.CommandLine.Compare
 
             if (options.Metadata)
             {
-                var expectedUtterances = Read<List<LabeledUtterance>>(options.ExpectedUtterancesPath);
+                var expectedUtterances = Read<List<CompareLabeledUtterance>>(options.ExpectedUtterancesPath);
                 var actualUtterances = Read<List<ScoredLabeledUtterance>>(options.ActualUtterancesPath);
                 var compareResults = TestCaseSource.GetNLUCompareResults(expectedUtterances, actualUtterances, options.CompareText);
                 var metadataPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestMetadataFileName) : TestMetadataFileName;

--- a/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
@@ -618,8 +618,6 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void UsesIndexAsUtteranceId()
         {
-            var entityType = Guid.NewGuid().ToString();
-            var matchText = Guid.NewGuid().ToString();
             var expectedUtterance = new LabeledUtterance(null, "Greeting", null);
             var actualUtterance = new LabeledUtterance(null, "Greeting", null);
             var compareResults = TestCaseSource.GetNLUCompareResults(
@@ -629,6 +627,20 @@ namespace NLU.DevOps.ModelPerformance.Tests
             compareResults.TestCases.Count.Should().Be(4);
             compareResults.TestCases.Where(t => t.UtteranceId == "0").Count().Should().Be(2);
             compareResults.TestCases.Where(t => t.UtteranceId == "1").Count().Should().Be(2);
+        }
+
+        [Test]
+        public static void UsesInputUtteranceId()
+        {
+            var utteranceId = Guid.NewGuid().ToString();
+            var expectedUtterance = new CompareLabeledUtterance(utteranceId, null, "Greeting", null);
+            var actualUtterance = new LabeledUtterance(null, "Greeting", null);
+            var compareResults = TestCaseSource.GetNLUCompareResults(
+                new[] { expectedUtterance },
+                new[] { actualUtterance },
+                false);
+            compareResults.TestCases.Count.Should().Be(2);
+            compareResults.TestCases.Where(t => t.UtteranceId == utteranceId).Count().Should().Be(2);
         }
 
         private static List<Entity> CreateEntityList(string type)

--- a/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
@@ -26,11 +26,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void TestToIntentTestCaseExpectingNoneActualDayTime()
         {
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                 new LabeledUtterance("FOO", "None", null),
                 new LabeledUtterance("FOO", "DayTime", null)
-            };
+            });
 
             var test = TestCaseSource.ToIntentTestCase(utterances);
 
@@ -41,11 +41,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void TestToIntentTestCaseActualNoneExpectingDayTime()
         {
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                 new LabeledUtterance("FOO", "DayTime", null),
                 new LabeledUtterance("FOO", "None", null)
-            };
+            });
 
             var test = TestCaseSource.ToIntentTestCase(utterances);
 
@@ -57,11 +57,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         public static void TestToEntityTestCasesMissingAnActualEntity()
         {
             var entity = CreateEntityList("EntityType");
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                 new LabeledUtterance("FOO", "DayTime", entity),
                 new LabeledUtterance("FOO", "DayTime", null)
-            };
+            });
 
             var actualTestResult = TestCaseSource.ToEntityTestCases(utterances);
 
@@ -74,11 +74,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = CreateEntityList("EntityType");
             var expectedEntity = CreateEntityList("WrongType");
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                  new LabeledUtterance("FOO", "DayTime", expectedEntity),
                  new LabeledUtterance("FOO", "DayTime", actualEntity)
-            };
+            });
 
             var actualTestResult = TestCaseSource.ToEntityTestCases(utterances);
 
@@ -98,11 +98,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var actualEntity = CreateEntityList("EntityType");
             actualEntity.Add(new Entity("RecognizedEntity", "value", "text", 2));
             var expectedEntity = CreateEntityList("EntityType");
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                 new LabeledUtterance("FOO", "DayTime", expectedEntity),
                 new LabeledUtterance("FOO", "DayTime", actualEntity)
-            };
+            });
 
             var actualTestResult = TestCaseSource.ToEntityTestCases(utterances);
 
@@ -122,11 +122,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         public static void TestToEntityTestCasesMissingEntityInActualResult()
         {
             var expectedEntity = CreateEntityList("EntityType");
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                 new LabeledUtterance("FOO", "DayTime", expectedEntity),
                 new LabeledUtterance("FOO", "DayTime", null)
-            };
+            });
 
             var actualTestResult = TestCaseSource.ToEntityTestCases(utterances);
 
@@ -142,11 +142,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = new[] { new Entity("EntityType", "differentEntityValue", "differentMatchedText", 1) };
             var expectedEntity = CreateEntityList("EntityType");
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                  new LabeledUtterance("FOO", "DayTime", expectedEntity),
                  new LabeledUtterance("FOO", "DayTime", actualEntity)
-            };
+            });
 
             var actualTestResult = TestCaseSource.ToEntityTestCases(utterances);
 
@@ -163,11 +163,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void ToTextTestCaseTrueNegative()
         {
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                 new LabeledUtterance(null, "DayTime", null),
                 new LabeledUtterance(null, "DayTime", null)
-            };
+            });
 
             var actualResult = TestCaseSource.ToTextTestCase(utterances);
 
@@ -177,11 +177,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void ToTextTestCaseFalseNegative()
          {
-             var utterances = new[]
+             var utterances = CreatePair(new[]
              {
                  new LabeledUtterance("foo", "DayTime", null),
                  new LabeledUtterance(null, "DayTime", null)
-             };
+             });
 
              var actualResult = TestCaseSource.ToTextTestCase(utterances);
 
@@ -191,11 +191,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void ToTextTestCaseTruePositive()
         {
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                 new LabeledUtterance("foo", "DayTime", null),
                 new LabeledUtterance("FOO", "DayTime", null)
-            };
+            });
 
             var actualResult = TestCaseSource.ToTextTestCase(utterances);
 
@@ -205,11 +205,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void ToTextTestCaseFalsePositive()
         {
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                 new LabeledUtterance("foo", "DayTime", null),
                 new LabeledUtterance("baz", "DayTime", null)
-            };
+            });
 
             var actualResult = TestCaseSource.ToTextTestCase(utterances);
 
@@ -231,11 +231,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = new List<Entity> { new Entity("EntityType", ParseEntityValueJson(actualJson), "foo", 1) };
             var expectedEntity = new List<Entity> { new Entity("EntityType", ParseEntityValueJson(expectedJson), "foo", 1) };
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                  new LabeledUtterance("FOO", "DayTime", expectedEntity),
                  new LabeledUtterance("FOO", "DayTime", actualEntity)
-            };
+            });
 
             var actualTestResult = TestCaseSource.ToEntityTestCases(utterances);
 
@@ -252,11 +252,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
             {
                 var actualEntity = new[] { new Entity("EntityType", 42, "differentMatchedText", 1) };
                 var expectedEntity = new[] { new Entity("EntityType", expectedEntityValue, "differentMatchedText", 1) };
-                var utterances = new[]
+                var utterances = CreatePair(new[]
                 {
                      new LabeledUtterance("FOO", "DayTime", expectedEntity),
                      new LabeledUtterance("FOO", "DayTime", actualEntity)
-                };
+                });
 
                 var actualTestResult = TestCaseSource.ToEntityTestCases(utterances);
 
@@ -271,11 +271,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = new[] { new Entity("EntityType", "EntityValue", "differentMatchedText", 1) };
             var expectedEntity = new[] { new Entity("EntityType", null, "differentMatchedText", 2) };
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                  new LabeledUtterance("FOO", "DayTime", expectedEntity),
                  new LabeledUtterance("FOO", "DayTime", actualEntity)
-            };
+            });
 
             var actualTestResult = TestCaseSource.ToEntityTestCases(utterances);
 
@@ -290,11 +290,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = new[] { new Entity("EntityType", "foo", null, 0) };
             var expectedEntity = new[] { new Entity("EntityType", null, "foo", 0) };
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                  new LabeledUtterance(null, null, expectedEntity),
                  new LabeledUtterance(null, null, actualEntity)
-            };
+            });
 
             var actualTestResult = TestCaseSource.ToEntityTestCases(utterances);
 
@@ -308,11 +308,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = new[] { new Entity("EntityType", "bar", null, 0) };
             var expectedEntity = new[] { new Entity("EntityType", "bar", "foo", 0) };
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                  new LabeledUtterance(null, null, expectedEntity),
                  new LabeledUtterance(null, null, actualEntity)
-            };
+            });
 
             var actualTestResult = TestCaseSource.ToEntityTestCases(utterances);
 
@@ -327,11 +327,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = new[] { new Entity("EntityType", "bar", "bar", 0) };
             var expectedEntity = new[] { new Entity("EntityType", "bar", "foo", 0) };
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                  new LabeledUtterance(null, null, expectedEntity),
                  new LabeledUtterance(null, null, actualEntity)
-            };
+            });
 
             var actualTestResult = TestCaseSource.ToEntityTestCases(utterances);
 
@@ -346,11 +346,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = new[] { new Entity("EntityType", null, "foo", 0) };
             var expectedEntity = new[] { new Entity("EntityType", "bar", "foo", 0) };
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                  new LabeledUtterance(null, null, expectedEntity),
                  new LabeledUtterance(null, null, actualEntity)
-            };
+            });
 
             var actualTestResult = TestCaseSource.ToEntityTestCases(utterances);
 
@@ -365,11 +365,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = new[] { new Entity("EntityType", "qux", "foo", 0) };
             var expectedEntity = new[] { new Entity("EntityType", "bar", "foo", 0) };
-            var utterances = new[]
+            var utterances = CreatePair(new[]
             {
                  new LabeledUtterance(null, null, expectedEntity),
                  new LabeledUtterance(null, null, actualEntity)
-            };
+            });
 
             var actualTestResult = TestCaseSource.ToEntityTestCases(utterances);
 
@@ -615,6 +615,22 @@ namespace NLU.DevOps.ModelPerformance.Tests
             testCase.Score.Should().Be(0.5);
         }
 
+        [Test]
+        public static void UsesIndexAsUtteranceId()
+        {
+            var entityType = Guid.NewGuid().ToString();
+            var matchText = Guid.NewGuid().ToString();
+            var expectedUtterance = new LabeledUtterance(null, "Greeting", null);
+            var actualUtterance = new LabeledUtterance(null, "Greeting", null);
+            var compareResults = TestCaseSource.GetNLUCompareResults(
+                new[] { expectedUtterance, expectedUtterance },
+                new[] { actualUtterance, actualUtterance },
+                false);
+            compareResults.TestCases.Count.Should().Be(4);
+            compareResults.TestCases.Where(t => t.UtteranceId == "0").Count().Should().Be(2);
+            compareResults.TestCases.Where(t => t.UtteranceId == "1").Count().Should().Be(2);
+        }
+
         private static List<Entity> CreateEntityList(string type)
         {
             return new List<Entity> { new Entity(type, "EntityValue", "matchedText", 1) };
@@ -628,6 +644,11 @@ namespace NLU.DevOps.ModelPerformance.Tests
         private static JToken ParseEntityValueJson(string json)
         {
             return json != null ? JToken.Parse(json) : null;
+        }
+
+        private static TestCaseSource.LabeledUtterancePair CreatePair(params LabeledUtterance[] pair)
+        {
+            return new TestCaseSource.LabeledUtterancePair(string.Empty, pair[0], pair[1]);
         }
     }
 }

--- a/src/NLU.DevOps.ModelPerformance/CompareLabeledUtterance.cs
+++ b/src/NLU.DevOps.ModelPerformance/CompareLabeledUtterance.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.ModelPerformance
+{
+    using System.Collections.Generic;
+    using Models;
+
+    /// <summary>
+    /// Labeled utterance with confidence score.
+    /// </summary>
+    public class CompareLabeledUtterance : LabeledUtterance
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompareLabeledUtterance"/> class.
+        /// </summary>
+        /// <param name="utteranceId">Utterance ID.</param>
+        /// <param name="text">Text of the utterance.</param>
+        /// <param name="intent">Intent of the utterance.</param>
+        /// <param name="entities">Entities referenced in the utterance.</param>
+        public CompareLabeledUtterance(string utteranceId, string text, string intent, IReadOnlyList<Entity> entities)
+            : base(text, intent, entities)
+        {
+            this.UtteranceId = utteranceId;
+        }
+
+        /// <summary>
+        /// Gets the utterance ID.
+        /// </summary>
+        public string UtteranceId { get; }
+    }
+}

--- a/src/NLU.DevOps.ModelPerformance/TestCase.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestCase.cs
@@ -15,6 +15,7 @@ namespace NLU.DevOps.ModelPerformance
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCase"/> class.
         /// </summary>
+        /// <param name="utteranceId">Utterance ID.</param>
         /// <param name="resultKind">Confusion matrix result kind.</param>
         /// <param name="targetKind">Comparison target kind.</param>
         /// <param name="expectedUtterance">Expected utterance.</param>
@@ -25,6 +26,7 @@ namespace NLU.DevOps.ModelPerformance
         /// <param name="because">Because.</param>
         /// <param name="categories">Categories.</param>
         public TestCase(
+            string utteranceId,
             ConfusionMatrixResultKind resultKind,
             ComparisonTargetKind targetKind,
             LabeledUtterance expectedUtterance,
@@ -35,6 +37,7 @@ namespace NLU.DevOps.ModelPerformance
             string because,
             IEnumerable<string> categories)
         {
+            this.UtteranceId = utteranceId;
             this.ResultKind = resultKind;
             this.TargetKind = targetKind;
             this.ExpectedUtterance = expectedUtterance;
@@ -45,6 +48,11 @@ namespace NLU.DevOps.ModelPerformance
             this.Because = because;
             this.Categories = categories.ToList();
         }
+
+        /// <summary>
+        /// Gets the utterance ID.
+        /// </summary>
+        public string UtteranceId { get; }
 
         /// <summary>
         /// Gets the test name.

--- a/src/NLU.DevOps.ModelPerformance/TestCaseSource.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestCaseSource.cs
@@ -68,8 +68,14 @@ namespace NLU.DevOps.ModelPerformance
                 throw new InvalidOperationException("Expected the same number of utterances in the expected and actual sources.");
             }
 
+            string getUtteranceId(LabeledUtterance utterance, int index)
+            {
+                var compareUtterance = utterance as CompareLabeledUtterance;
+                return compareUtterance?.UtteranceId ?? index.ToString(CultureInfo.InvariantCulture);
+            }
+
             var zippedUtterances = expectedUtterances
-                .Select((utterance, i) => new { Utterance = utterance, UtteranceId = i.ToString(CultureInfo.InvariantCulture) })
+                .Select((utterance, i) => new { Utterance = utterance, UtteranceId = getUtteranceId(utterance, i) })
                 .Zip(actualUtterances, (expected, actual) => new LabeledUtterancePair(expected.UtteranceId, expected.Utterance, actual))
                 .ToList();
 


### PR DESCRIPTION
Adds an utterance ID to each test case that can be used to aggregate results and check whether an utterance is matched 100% correctly.

Fixes #174