### PR TITLE
Fixes support for LUIS batch test format

### DIFF
--- a/src/NLU.DevOps.Core.Tests/LabeledUtteranceConverterTests.cs
+++ b/src/NLU.DevOps.Core.Tests/LabeledUtteranceConverterTests.cs
@@ -195,6 +195,28 @@ namespace NLU.DevOps.Core.Tests
             toObject.Should().Throw<ArgumentException>();
         }
 
+        [Test]
+        public static void DeserializesEntityType()
+        {
+            var entityJson = new JObject
+            {
+                { "startPos", 0 },
+                { "endPos", 2 },
+                { "entity", "bar" },
+            };
+
+            var json = new JObject
+            {
+                { "text", "foo" },
+                { "entities", new JArray { entityJson } },
+            };
+
+            var serializer = CreateSerializer();
+            var utterance = json.ToObject<LabeledUtterance>(serializer);
+            utterance.Entities.Count.Should().Be(1);
+            utterance.Entities[0].EntityType.Should().Be("bar");
+        }
+
         private static JsonSerializer CreateSerializer()
         {
             var serializer = JsonSerializer.CreateDefault();

--- a/src/NLU.DevOps.Core/LabeledUtteranceConverter.cs
+++ b/src/NLU.DevOps.Core/LabeledUtteranceConverter.cs
@@ -9,7 +9,7 @@ namespace NLU.DevOps.Core
     using Newtonsoft.Json.Linq;
 
     /// <summary>
-    /// JSON converter for <see cref="LabeledUtterance"/>.
+    /// JSON converter for <see cref="LabeledUtterance"/> to recognize LUIS batch test format.
     /// </summary>
     public class LabeledUtteranceConverter : JsonConverter<LabeledUtterance>
     {
@@ -95,6 +95,14 @@ namespace NLU.DevOps.Core
                     jsonObject.Add("matchIndex", matchIndex);
                     jsonObject.Remove("startPos");
                     jsonObject.Remove("endPos");
+                }
+
+                var entity = jsonObject.Value<string>("entity");
+                var entityType = jsonObject.Value<string>("entityType");
+                if (entityType == null && entity != null)
+                {
+                    jsonObject.Add("entityType", entity);
+                    jsonObject.Remove("entity");
                 }
 
                 serializer.Converters.Remove(this);


### PR DESCRIPTION
LUIS batch uses `entity` instead of `entityType` for the type of entity matched. This change updates the Json.NET converter to also look for `entity` in cases where `entityType` is missing.

Fixes #191