### PR TITLE
Constrain the "azure-pipelines-task-lib" version to 2.8.x

### DIFF
--- a/extensions/common/nlu-devops-common/package.json
+++ b/extensions/common/nlu-devops-common/package.json
@@ -2,6 +2,6 @@
     "name": "nlu-devops-common",
     "version": "0.1.5",
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.8.0"
+        "azure-pipelines-task-lib": "~2.8.0"
     }
 }

--- a/extensions/tasks/NLUCleanV0/package.json
+++ b/extensions/tasks/NLUCleanV0/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "azure-pipelines-task-lib": "^2.8.0",
+    "azure-pipelines-task-lib": "~2.8.0",
     "nlu-devops-common": "file:../../nlu-devops-common-0.1.5.tgz"
   }
 }

--- a/extensions/tasks/NLUTestV0/package.json
+++ b/extensions/tasks/NLUTestV0/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "azure-devops-node-api": "^9.0.1",
-    "azure-pipelines-task-lib": "^2.8.0",
+    "azure-pipelines-task-lib": "~2.8.0",
     "nlu-devops-common": "file:../../nlu-devops-common-0.1.5.tgz",
     "unzip-stream": "^0.3.0"
   }

--- a/extensions/tasks/NLUTrainV0/package.json
+++ b/extensions/tasks/NLUTrainV0/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "azure-pipelines-task-lib": "^2.8.0",
+    "azure-pipelines-task-lib": "~2.8.0",
     "nlu-devops-common": "file:../../nlu-devops-common-0.1.5.tgz"
   }
 }


### PR DESCRIPTION
A minor breaking change was introduced in 2.9.3, for now we will just constrain the version to 2.8.x.