### PR TITLE
Adds a `--qps` CLI option to the test command

### DIFF
--- a/src/NLU.DevOps.CommandLine.Tests/EnumerableExtensionsTests.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/EnumerableExtensionsTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.CommandLine.Tests
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    [TestFixture]
+    internal static class EnumerableExtensionsTests
+    {
+        [Test]
+        public static async Task LimitsQueriesPerSecond()
+        {
+            Task<Tuple<int, DateTimeOffset>> TimestampAsync(int item) =>
+                Task.FromResult(Tuple.Create(item, DateTimeOffset.Now));
+
+            var items = Enumerable.Range(0, 101).ToList();
+            var results = await items.SelectAsync(TimestampAsync, 10, 50).ConfigureAwait(false);
+
+            results.Select(x => x.Item1).Should().BeEquivalentTo(items);
+
+            for (var i = 51; i < items.Count; ++i)
+            {
+                var delay = results[i].Item2 - results[i - 50].Item2;
+                delay.Should().BeGreaterThan(TimeSpan.FromSeconds(1));
+            }
+        }
+    }
+}

--- a/src/NLU.DevOps.CommandLine/Test/TestCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Test/TestCommand.cs
@@ -6,6 +6,7 @@ namespace NLU.DevOps.CommandLine.Test
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Threading.Tasks;
     using Models;
     using Newtonsoft.Json.Linq;
@@ -47,8 +48,12 @@ namespace NLU.DevOps.CommandLine.Test
         {
             this.Log("Running tests against NLU model...");
 
-            var testUtterances = this.LoadUtterances();
-            var testResults = await testUtterances.SelectAsync(this.TestAsync, this.Options.Parallelism).ConfigureAwait(false);
+            var testUtterances = this.LoadUtterances().ToList();
+            var testResults = await testUtterances.SelectAsync(
+                    this.TestAsync,
+                    this.Options.Parallelism,
+                    this.Options.QueriesPerSecond)
+                .ConfigureAwait(false);
 
             Stream getFileStream(string filePath)
             {

--- a/src/NLU.DevOps.CommandLine/Test/TestOptions.cs
+++ b/src/NLU.DevOps.CommandLine/Test/TestOptions.cs
@@ -25,5 +25,8 @@ namespace NLU.DevOps.CommandLine.Test
 
         [Option('p', "parallelism", HelpText = "Numeric value to determine the numer of parallel tests.  Default value is 3.", Required = false)]
         public int Parallelism { get; set; } = 3;
+
+        [Option("qps", HelpText = "Queries per second to run.", Required = false)]
+        public int QueriesPerSecond { get; set; }
     }
 }


### PR DESCRIPTION
For services that have constraints, e.g., 180 requests per minute for Dialogflow or 10 requests per second for LUIS, this flag can be used to ensure we make at most the provided number of queries per second.