### PR TITLE
Adds intents to LUIS output

### DIFF
--- a/src/NLU.DevOps.Core.Tests/LabeledUtterancePropertyExtensionsTests.cs
+++ b/src/NLU.DevOps.Core.Tests/LabeledUtterancePropertyExtensionsTests.cs
@@ -47,11 +47,13 @@ namespace NLU.DevOps.Core.Tests
             var utterance = new LabeledUtterance(null, null, null)
                 .WithScore(0.42)
                 .WithTextScore(0.5)
-                .WithTimestamp(DateTimeOffset.Now.Date);
+                .WithTimestamp(DateTimeOffset.Now.Date)
+                .WithProperty("foo", new[] { 42 });
             var roundtrip = JToken.FromObject(utterance).ToObject<JsonLabeledUtterance>();
             roundtrip.GetScore().Should().BeApproximately(utterance.GetScore(), Epsilon);
             roundtrip.GetTextScore().Should().BeApproximately(utterance.GetTextScore(), Epsilon);
             roundtrip.GetTimestamp().Should().Be(utterance.GetTimestamp());
+            roundtrip.GetProperty<JArray>("foo").Should().BeEquivalentTo(new[] { 42 });
         }
 
         [Test]

--- a/src/NLU.DevOps.Core/LabeledUtterancePropertyExtensions.cs
+++ b/src/NLU.DevOps.Core/LabeledUtterancePropertyExtensions.cs
@@ -51,6 +51,18 @@ namespace NLU.DevOps.Core
         }
 
         /// <summary>
+        /// Adds a property to the labeled utterance.
+        /// </summary>
+        /// <param name="instance">Labeled utterance instance.</param>
+        /// <param name="propertyName">Property name.</param>
+        /// <param name="propertyValue">Property value.</param>
+        /// <returns>Labeled utterance with additional property.</returns>
+        public static LabeledUtterance WithProperty(this LabeledUtterance instance, string propertyName, object propertyValue)
+        {
+            return instance.WithProperty(propertyName, propertyValue, ToJsonLabeledUtterance);
+        }
+
+        /// <summary>
         /// Adds a confidence score to the entity.
         /// </summary>
         /// <param name="instance">Entity instance.</param>
@@ -70,7 +82,7 @@ namespace NLU.DevOps.Core
         /// </returns>
         public static double? GetScore(this LabeledUtterance instance)
         {
-            return instance.GetProperty<double?>(ScorePropertyName);
+            return instance.GetPropertyCore<double?>(ScorePropertyName);
         }
 
         /// <summary>
@@ -82,7 +94,7 @@ namespace NLU.DevOps.Core
         /// </returns>
         public static double? GetTextScore(this LabeledUtterance instance)
         {
-            return instance.GetProperty<double?>(TextScorePropertyName);
+            return instance.GetPropertyCore<double?>(TextScorePropertyName);
         }
 
         /// <summary>
@@ -94,7 +106,21 @@ namespace NLU.DevOps.Core
         /// </returns>
         public static DateTimeOffset? GetTimestamp(this LabeledUtterance instance)
         {
-            return instance.GetProperty<DateTimeOffset?>(TimestampPropertyName);
+            return instance.GetPropertyCore<DateTimeOffset?>(TimestampPropertyName);
+        }
+
+        /// <summary>
+        /// Gets the property for the labeled utterance.
+        /// </summary>
+        /// <typeparam name="T">Property value type.</typeparam>
+        /// <param name="instance">Labeled utterance instance.</param>
+        /// <param name="propertyName">Property name.</param>
+        /// <returns>
+        /// Property value, or default if property is not set.
+        /// </returns>
+        public static T GetProperty<T>(this LabeledUtterance instance, string propertyName)
+        {
+            return instance.GetPropertyCore<T>(propertyName);
         }
 
         /// <summary>
@@ -104,7 +130,7 @@ namespace NLU.DevOps.Core
         /// <returns>Utterance identifier.</returns>
         public static string GetUtteranceId(this LabeledUtterance instance)
         {
-            return instance.GetProperty<string>(UtteranceIdPropertyName);
+            return instance.GetPropertyCore<string>(UtteranceIdPropertyName);
         }
 
         /// <summary>
@@ -116,7 +142,7 @@ namespace NLU.DevOps.Core
         /// </returns>
         public static double? GetScore(this Entity instance)
         {
-            return instance.GetProperty<double?>(ScorePropertyName);
+            return instance.GetPropertyCore<double?>(ScorePropertyName);
         }
 
         private static T WithProperty<T, TResult>(
@@ -156,7 +182,7 @@ namespace NLU.DevOps.Core
                 : new JsonEntity(entity.EntityType, entity.EntityValue, entity.MatchText, entity.MatchIndex);
         }
 
-        private static T GetProperty<T>(this object instance, string propertyName)
+        private static T GetPropertyCore<T>(this object instance, string propertyName)
         {
             if (instance is IJsonExtension jsonExtension && jsonExtension.AdditionalProperties.TryGetValue(propertyName, out var value))
             {

--- a/src/NLU.DevOps.Luis.Tests/LuisNLUTestClientTests.cs
+++ b/src/NLU.DevOps.Luis.Tests/LuisNLUTestClientTests.cs
@@ -13,7 +13,9 @@ namespace NLU.DevOps.Luis.Tests
     using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.Models;
     using Models;
     using Moq;
+    using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
+    using Newtonsoft.Json.Serialization;
     using NUnit.Framework;
 
     [TestFixture]
@@ -428,6 +430,42 @@ namespace NLU.DevOps.Luis.Tests
                 var result = await luis.TestAsync(test).ConfigureAwait(false);
                 result.Entities.Count.Should().Be(1);
                 result.Entities[0].EntityType.Should().Be("role");
+            }
+        }
+
+        [Test]
+        public static async Task WithMultipleIntents()
+        {
+            var test = "the quick brown fox jumped over the lazy dog";
+
+            var builder = new LuisNLUTestClientBuilder();
+            builder.LuisTestClientMock
+                .Setup(luis => luis.QueryAsync(
+                    It.Is<string>(query => query == test),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult(new LuisResult
+                {
+                    Query = test,
+                    TopScoringIntent = new IntentModel { Intent = "intent", Score = 0.42 },
+                    Intents = new[]
+                    {
+                        new IntentModel { Intent = "intent", Score = 0.42 },
+                        new IntentModel { Intent = "foo", Score = 0.07 },
+                    },
+                }));
+
+            using (var luis = builder.Build())
+            {
+                var result = await luis.TestAsync(test).ConfigureAwait(false);
+                result.Should().BeOfType(typeof(JsonLabeledUtterance));
+                var serializer = JsonSerializer.CreateDefault();
+                serializer.ContractResolver = new CamelCasePropertyNamesContractResolver();
+                var intents = JArray.FromObject(result.GetProperty<object>("intents"), serializer);
+                intents.Count.Should().Be(2);
+                intents[0].Value<string>("intent").Should().Be("intent");
+                intents[0].Value<double>("score").Should().Be(0.42);
+                intents[1].Value<string>("intent").Should().Be("foo");
+                intents[1].Value<double>("score").Should().Be(0.07);
             }
         }
 

--- a/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
@@ -146,6 +146,7 @@ namespace NLU.DevOps.Luis
                     speechLuisResult.LuisResult.Query,
                     speechLuisResult.LuisResult.TopScoringIntent?.Intent,
                     speechLuisResult.LuisResult.Entities?.Select(getEntity).ToList())
+                .WithProperty("intents", speechLuisResult.LuisResult.Intents)
                 .WithScore(speechLuisResult.LuisResult.TopScoringIntent?.Score)
                 .WithTextScore(speechLuisResult.TextScore)
                 .WithTimestamp(DateTimeOffset.Now);

--- a/src/NLU.DevOps.LuisV3/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.LuisV3/LuisNLUTestClient.cs
@@ -174,9 +174,11 @@ namespace NLU.DevOps.Luis
                 .ToList();
 
             var intent = speechPredictionResponse.PredictionResponse.Prediction.TopIntent;
+            var intents = speechPredictionResponse.PredictionResponse.Prediction.Intents?.Select(i => new { Intent = i.Key, i.Value.Score });
             var intentData = default(Intent);
             speechPredictionResponse.PredictionResponse.Prediction.Intents?.TryGetValue(intent, out intentData);
             return new LabeledUtterance(query, intent, entities)
+                .WithProperty("intents", intents)
                 .WithScore(intentData?.Score)
                 .WithTextScore(speechPredictionResponse.TextScore)
                 .WithTimestamp(DateTimeOffset.Now);


### PR DESCRIPTION
When multiple intents are returned by LUIS, this change ensures those intents and their corresponding scores end up in the `test` command output.

Fixes #212