### PR TITLE
Adds fix to LUIS v2 provider for match index

### DIFF
--- a/src/NLU.DevOps.Luis.Tests/LuisNLUTestClientTests.cs
+++ b/src/NLU.DevOps.Luis.Tests/LuisNLUTestClientTests.cs
@@ -469,6 +469,41 @@ namespace NLU.DevOps.Luis.Tests
             }
         }
 
+        [Test]
+        public static async Task EntityTextDoesNotMatch()
+        {
+            var test = "show me past - due my past-due tasks";
+
+            var builder = new LuisNLUTestClientBuilder();
+            builder.LuisTestClientMock
+                .Setup(luis => luis.QueryAsync(
+                    It.Is<string>(query => query == test),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult(new LuisResult
+                {
+                    Query = test,
+                    TopScoringIntent = new IntentModel { Intent = "intent" },
+                    Entities = new[]
+                    {
+                        new EntityModel
+                        {
+                            Entity = "past - due",
+                            Type = "status",
+                            StartIndex = 22,
+                            EndIndex = 29,
+                        },
+                    },
+                }));
+
+            using (var luis = builder.Build())
+            {
+                var result = await luis.TestAsync(test).ConfigureAwait(false);
+                result.Entities.Count.Should().Be(1);
+                result.Entities[0].MatchText.Should().Be("past-due");
+                result.Entities[0].MatchIndex.Should().Be(0);
+            }
+        }
+
         private class LuisNLUTestClientBuilder
         {
             public LuisSettings LuisSettings { get; set; } = new LuisSettings(null, null, null);

--- a/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
@@ -116,7 +116,7 @@ namespace NLU.DevOps.Luis
                     entityValue = GetEntityValue(resolutionJson);
                 }
 
-                var matchText = entity.Entity;
+                var matchText = speechLuisResult.LuisResult.Query.Substring(entity.StartIndex, entity.EndIndex - entity.StartIndex + 1);
                 var matches = Regex.Matches(speechLuisResult.LuisResult.Query, matchText, RegexOptions.IgnoreCase);
                 var matchIndex = -1;
                 for (var i = 0; i < matches.Count; ++i)


### PR DESCRIPTION
The "entity" value returned by LUIS v2 does not always match the utterance, so we need to grab the entity value using the "startIndex" and "endIndex".

Fixes #219