### PR TITLE
Use LUIS resolution value as-is for entityValue

### DIFF
--- a/models/tests.json
+++ b/models/tests.json
@@ -37,7 +37,9 @@
         "entityType": "songCount",
         "matchText": "five",
         "matchIndex": 0,
-        "entityValue": "5"
+        "entityValue": {
+          "value": "5"
+        }
       }
     ]
   },

--- a/src/NLU.DevOps.Luis.Tests/LuisNLUTestClientTests.cs
+++ b/src/NLU.DevOps.Luis.Tests/LuisNLUTestClientTests.cs
@@ -136,9 +136,9 @@ namespace NLU.DevOps.Luis.Tests
             {
                 var result = await luis.TestAsync(test).ConfigureAwait(false);
                 result.Entities.Count.Should().Be(3);
-                result.Entities[0].EntityValue.Should().BeEquivalentTo(valueResolution["value"]);
-                result.Entities[1].EntityValue.Should().BeEquivalentTo(valuesStringResolution["values"]);
-                result.Entities[2].EntityValue.Should().BeEquivalentTo(valuesValueResolution["values"]);
+                result.Entities[0].EntityValue.Should().BeEquivalentTo(valueResolution);
+                result.Entities[1].EntityValue.Should().BeEquivalentTo(valuesStringResolution);
+                result.Entities[2].EntityValue.Should().BeEquivalentTo(valuesValueResolution);
             }
         }
 

--- a/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
@@ -59,28 +59,6 @@ namespace NLU.DevOps.Luis
             this.LuisClient.Dispose();
         }
 
-        private static JToken GetEntityValue(JToken resolution)
-        {
-            if (resolution == null)
-            {
-                return null;
-            }
-
-            var value = resolution["value"];
-            if (value != null)
-            {
-                return value;
-            }
-
-            var values = resolution["values"];
-            if (values != null)
-            {
-                return values;
-            }
-
-            return resolution;
-        }
-
         private LabeledUtterance LuisResultToLabeledUtterance(SpeechLuisResult speechLuisResult)
         {
             if (speechLuisResult == null)
@@ -113,7 +91,7 @@ namespace NLU.DevOps.Luis
                     entity.AdditionalProperties.TryGetValue("resolution", out var resolution) &&
                     resolution is JToken resolutionJson)
                 {
-                    entityValue = GetEntityValue(resolutionJson);
+                    entityValue = resolutionJson;
                 }
 
                 var matchText = speechLuisResult.LuisResult.Query.Substring(entity.StartIndex, entity.EndIndex - entity.StartIndex + 1);

--- a/src/NLU.DevOps.LuisV3.Tests/LuisNLUTestClientTests.cs
+++ b/src/NLU.DevOps.LuisV3.Tests/LuisNLUTestClientTests.cs
@@ -399,42 +399,6 @@ namespace NLU.DevOps.Luis.Tests
             }
         }
 
-        private static IDictionary<string, object> ToEntityDictionary(IEnumerable<EntityModel> entities)
-        {
-            var result = new Dictionary<string, object>();
-            foreach (var entity in entities)
-            {
-                if (!result.TryGetValue(entity.Type, out var value))
-                {
-                    result.Add(entity.Type, new JArray());
-                    if (!result.TryGetValue("$instance", out var instanceValue))
-                    {
-                        instanceValue = new JObject();
-                        result.Add("$instance", instanceValue);
-                    }
-
-                    var instanceJson = (JObject)instanceValue;
-                    instanceJson.Add(entity.Type, new JArray());
-                }
-
-                var entityMetadata = new JObject
-                {
-                    { "startIndex", entity.StartIndex },
-                    { "length", entity.EndIndex - entity.StartIndex + 1 }
-                };
-
-                if (entity.AdditionalProperties != null && entity.AdditionalProperties.TryGetValue("score", out var score))
-                {
-                    entityMetadata.Add("score", (double)score);
-                }
-
-                ((JArray)result[entity.Type]).Add(entity.Entity);
-                ((JArray)((JObject)result["$instance"])[entity.Type]).Add(entityMetadata);
-            }
-
-            return result;
-        }
-
         [Test]
         public static async Task EntityTextDoesNotMatch()
         {
@@ -471,6 +435,42 @@ namespace NLU.DevOps.Luis.Tests
                 result.Entities[0].MatchText.Should().Be("past-due");
                 result.Entities[0].MatchIndex.Should().Be(0);
             }
+        }
+
+        private static IDictionary<string, object> ToEntityDictionary(IEnumerable<EntityModel> entities)
+        {
+            var result = new Dictionary<string, object>();
+            foreach (var entity in entities)
+            {
+                if (!result.TryGetValue(entity.Type, out var value))
+                {
+                    result.Add(entity.Type, new JArray());
+                    if (!result.TryGetValue("$instance", out var instanceValue))
+                    {
+                        instanceValue = new JObject();
+                        result.Add("$instance", instanceValue);
+                    }
+
+                    var instanceJson = (JObject)instanceValue;
+                    instanceJson.Add(entity.Type, new JArray());
+                }
+
+                var entityMetadata = new JObject
+                {
+                    { "startIndex", entity.StartIndex },
+                    { "length", entity.EndIndex - entity.StartIndex + 1 }
+                };
+
+                if (entity.AdditionalProperties != null && entity.AdditionalProperties.TryGetValue("score", out var score))
+                {
+                    entityMetadata.Add("score", (double)score);
+                }
+
+                ((JArray)result[entity.Type]).Add(entity.Entity);
+                ((JArray)((JObject)result["$instance"])[entity.Type]).Add(entityMetadata);
+            }
+
+            return result;
         }
 
         private class LuisNLUTestClientBuilder


### PR DESCRIPTION
Rather than extracting the LUIS resolution property in LUIS v2 (to match the output from LUIS v3), this change simply puts the resolution value as-is in the entityValue property of the generic utterance format.

Fixes #221