### PR TITLE
Fixes camelcase issue with `compare` statistics output

### DIFF
--- a/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
@@ -9,6 +9,7 @@ namespace NLU.DevOps.CommandLine.Compare
     using System.Linq;
     using Core;
     using ModelPerformance;
+    using Newtonsoft.Json.Linq;
     using NUnitLite;
     using static Serializer;
 
@@ -39,7 +40,7 @@ namespace NLU.DevOps.CommandLine.Compare
                 var metadataPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestMetadataFileName) : TestMetadataFileName;
                 var statisticsPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestStatisticsFileName) : TestStatisticsFileName;
                 Write(metadataPath, compareResults.TestCases);
-                Write(statisticsPath, compareResults.Statistics);
+                File.WriteAllText(statisticsPath, JObject.FromObject(compareResults.Statistics).ToString());
             }
 
             new AutoRun(typeof(ConfigurationConstants).Assembly).Execute(arguments.ToArray());

--- a/src/NLU.DevOps.ModelPerformance/NLUStatistics.cs
+++ b/src/NLU.DevOps.ModelPerformance/NLUStatistics.cs
@@ -4,6 +4,7 @@
 namespace NLU.DevOps.ModelPerformance
 {
     using System.Collections.Generic;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// NLU statistics.
@@ -41,36 +42,43 @@ namespace NLU.DevOps.ModelPerformance
         /// <summary>
         /// Gets the text confusion matrix.
         /// </summary>
+        [JsonProperty(PropertyName = "text")]
         public ConfusionMatrix Text { get; }
 
         /// <summary>
         /// Gets the intent confusion matrix.
         /// </summary>
+        [JsonProperty(PropertyName = "intent")]
         public ConfusionMatrix Intent { get; }
 
         /// <summary>
         /// Gets the entity confusion matrix.
         /// </summary>
+        [JsonProperty(PropertyName = "entity")]
         public ConfusionMatrix Entity { get; }
 
         /// <summary>
         /// Gets the entity value confusion matrix.
         /// </summary>
+        [JsonProperty(PropertyName = "entityValue")]
         public ConfusionMatrix EntityValue { get; }
 
         /// <summary>
         /// Gets the intent confusion matrix by intent.
         /// </summary>
+        [JsonProperty(PropertyName = "byIntent")]
         public IReadOnlyDictionary<string, ConfusionMatrix> ByIntent { get; }
 
         /// <summary>
         /// Gets the entity confusion matrix by entity type.
         /// </summary>
+        [JsonProperty(PropertyName = "byEntityType")]
         public IReadOnlyDictionary<string, ConfusionMatrix> ByEntityType { get; }
 
         /// <summary>
         /// Gets the entity value confusion matrix by entity type.
         /// </summary>
+        [JsonProperty(PropertyName = "byEntityValueType")]
         public IReadOnlyDictionary<string, ConfusionMatrix> ByEntityValueType { get; }
     }
 }


### PR DESCRIPTION
The serialization for NLU.DevOps uses the camelcase formatter. We actually don't want the intent and entity type name casing to be changed in the statistics output so this change switches the serialization method.

Fixes #218