### PR TITLE
Bumps NuGet version to 0.6.0

### DIFF
--- a/src/CommonNuget.props
+++ b/src/CommonNuget.props
@@ -8,6 +8,6 @@
     <PackageProjectUrl>https://github.com/Microsoft/NLU.DevOps</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Microsoft/NLU.DevOps.git</RepositoryUrl>
     <Copyright>© Microsoft Corporation.</Copyright>
-    <Version>0.5.6</Version>
+    <Version>0.6.0</Version>
   </PropertyGroup>
 </Project>

--- a/src/NLU.DevOps.Core/NLU.DevOps.Core.csproj
+++ b/src/NLU.DevOps.Core/NLU.DevOps.Core.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CodeAnalysis.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>0.5.0</AssemblyVersion>
+    <AssemblyVersion>0.6.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">

--- a/src/NLU.DevOps.Models/NLU.DevOps.Models.csproj
+++ b/src/NLU.DevOps.Models/NLU.DevOps.Models.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CodeAnalysis.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>0.5.0</AssemblyVersion>
+    <AssemblyVersion>0.6.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">


### PR DESCRIPTION
Given breaking change to LUIS v2 format, bumps version to 0.6.0 in preparation for release.