### PR TITLE
Fixes bug introduced by statistics serialization change

### DIFF
--- a/src/NLU.DevOps.CommandLine/Serializer.cs
+++ b/src/NLU.DevOps.CommandLine/Serializer.cs
@@ -37,7 +37,6 @@ namespace NLU.DevOps.CommandLine
             serializer.ContractResolver = new CamelCasePropertyNamesContractResolver();
             serializer.DefaultValueHandling = DefaultValueHandling.Ignore;
             serializer.Converters.Add(new StringEnumConverter());
-            serializer.Converters.Add(new ConfusionMatrixConverter());
             serializer.Formatting = Formatting.Indented;
             using (var textWriter = new StreamWriter(stream, Encoding.UTF8, 4096, true))
             {

--- a/src/NLU.DevOps.ModelPerformance.Tests/ConfusionMatrixConverterTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/ConfusionMatrixConverterTests.cs
@@ -39,6 +39,25 @@ namespace NLU.DevOps.ModelPerformance.Tests
             json.Value<int>(3).Should().Be(0);
         }
 
+        [Test]
+        public static void UsesConverterByDefault()
+        {
+            var value = new ConfusionMatrixContainer
+            {
+                Data = new ConfusionMatrix(42, 7, 1, 0),
+            };
+
+            var json = JToken.FromObject(value, JsonSerializer.CreateDefault());
+            json.Type.Should().Be(JTokenType.Object);
+            json.As<JObject>().ContainsKey("Data").Should().BeTrue();
+            json["Data"].Type.Should().Be(JTokenType.Array);
+            json["Data"].As<JArray>().Count.Should().Be(4);
+            json["Data"].Value<int>(0).Should().Be(42);
+            json["Data"].Value<int>(1).Should().Be(7);
+            json["Data"].Value<int>(2).Should().Be(1);
+            json["Data"].Value<int>(3).Should().Be(0);
+        }
+
         private class ConfusionMatrixContainer
         {
             public ConfusionMatrix Data { get; set; }

--- a/src/NLU.DevOps.ModelPerformance/ConfusionMatrix.cs
+++ b/src/NLU.DevOps.ModelPerformance/ConfusionMatrix.cs
@@ -3,9 +3,12 @@
 
 namespace NLU.DevOps.ModelPerformance
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// Confusion matrix container.
     /// </summary>
+    [JsonConverter(typeof(ConfusionMatrixConverter))]
     public class ConfusionMatrix
     {
         /// <summary>


### PR DESCRIPTION
The change to avoid camel-casing intent names in the statistics output left out the confusion matrix conversion logic that printed the results as an array of numbers.