### PR TITLE
Minor fix to LUIS test clients to accommodate changes to speech API

### DIFF
--- a/src/NLU.DevOps.Luis.Shared/LuisConfiguration.cs
+++ b/src/NLU.DevOps.Luis.Shared/LuisConfiguration.cs
@@ -44,8 +44,8 @@ namespace NLU.DevOps.Luis
         private const string ArmTokenConfigurationKey = "ARM_TOKEN";
         private const string BuildIdConfigurationKey = "BUILD_BUILDID";
 
-        private const string CustomSpeechEndpointTemplate = "https://{0}.stt.speech.microsoft.com/speech/recognition/interactive/cognitiveservices/v1?language={1}&?cid={2}";
-        private const string SpeechEndpointTemplate = "https://{0}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language={1}";
+        private const string CustomSpeechEndpointTemplate = "https://{0}.stt.speech.microsoft.com/speech/recognition/interactive/cognitiveservices/v1?language={1}&cid={2}&format=detailed";
+        private const string SpeechEndpointTemplate = "https://{0}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language={1}&format=detailed";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LuisConfiguration"/> class.

--- a/src/NLU.DevOps.Luis.Tests.Shared/LuisConfigurationTests.cs
+++ b/src/NLU.DevOps.Luis.Tests.Shared/LuisConfigurationTests.cs
@@ -204,7 +204,7 @@ namespace NLU.DevOps.Luis.Tests
             luisConfiguration.SpeechEndpoint.Should().Be(
                 new Uri(string.Format(
                     CultureInfo.InvariantCulture,
-                    @"https://{0}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language=en-US",
+                    @"https://{0}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language=en-US&format=detailed",
                     regionValue)));
         }
 
@@ -225,7 +225,7 @@ namespace NLU.DevOps.Luis.Tests
             luisConfiguration.SpeechEndpoint.Should().Be(
                 new Uri(string.Format(
                     CultureInfo.InvariantCulture,
-                    @"https://{0}.stt.speech.microsoft.com/speech/recognition/interactive/cognitiveservices/v1?language=en-US&?cid={1}",
+                    @"https://{0}.stt.speech.microsoft.com/speech/recognition/interactive/cognitiveservices/v1?language=en-US&cid={1}&format=detailed",
                     regionValue,
                     appId)));
         }
@@ -244,7 +244,7 @@ namespace NLU.DevOps.Luis.Tests
             luisConfiguration.SpeechEndpoint.Should().Be(
                 string.Format(
                     CultureInfo.InvariantCulture,
-                    @"https://{0}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language=en-US",
+                    @"https://{0}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language=en-US&format=detailed",
                     speechRegion));
         }
 #if LUIS_V2


### PR DESCRIPTION
Updates the LUIS client to use the detailed response from the Cognitive Services Speech API, so it can get the confidence score.