### PR TITLE
Fixes issue with using regex to find match text

### DIFF
--- a/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
@@ -95,16 +95,15 @@ namespace NLU.DevOps.Luis
                     entityValue = resolutionJson;
                 }
 
-                var matchText = speechLuisResult.LuisResult.Query.Substring(entity.StartIndex, entity.EndIndex - entity.StartIndex + 1);
-                var matches = Regex.Matches(speechLuisResult.LuisResult.Query, matchText, RegexOptions.IgnoreCase);
-                var matchIndex = -1;
-                for (var i = 0; i < matches.Count; ++i)
+                var utterance = speechLuisResult.LuisResult.Query;
+                var startIndex = entity.StartIndex;
+                var matchText = utterance.Substring(startIndex, entity.EndIndex - startIndex + 1);
+                var matchIndex = 0;
+                var currentStart = 0;
+                while ((currentStart = utterance.IndexOf(matchText, currentStart, StringComparison.Ordinal)) != startIndex)
                 {
-                    if (matches[i].Index == entity.StartIndex)
-                    {
-                        matchIndex = i;
-                        break;
-                    }
+                    ++matchIndex;
+                    currentStart++;
                 }
 
                 Debug.Assert(matchIndex >= 0, "Invalid LUIS response.");

--- a/src/NLU.DevOps.LuisV3/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.LuisV3/LuisNLUTestClient.cs
@@ -92,11 +92,10 @@ namespace NLU.DevOps.Luis
                 var matchText = utterance.Substring(startIndex, length);
                 var matchIndex = 0;
                 var currentStart = 0;
-                var nextStart = 0;
-                while ((nextStart = utterance.IndexOf(matchText, currentStart, StringComparison.Ordinal)) != startIndex)
+                while ((currentStart = utterance.IndexOf(matchText, currentStart, StringComparison.Ordinal)) != startIndex)
                 {
                     ++matchIndex;
-                    currentStart = nextStart + 1;
+                    currentStart++;
                 }
 
                 var entityValue = PruneMetadata(entityJson);


### PR DESCRIPTION
LUIS v2 utterance converter fails when the match text contains regex syntax (e.g., parentheses). This fix switches the implemenetation to use ordinal string search to find the match text and index for generic utterance format.