### PR TITLE
Convert retry log warnings to traces

### DIFF
--- a/src/NLU.DevOps.Dialogflow/DialogflowNLUTestClient.cs
+++ b/src/NLU.DevOps.Dialogflow/DialogflowNLUTestClient.cs
@@ -138,7 +138,7 @@ namespace NLU.DevOps.Dialogflow
                 catch (RpcException ex)
                 when (ex.StatusCode == StatusCode.ResourceExhausted)
                 {
-                    Logger.LogWarning("Received HTTP 429 result from Dialogflow. Retrying in 30 seconds.");
+                    Logger.LogTrace("Received HTTP 429 result from Dialogflow. Retrying in 30 seconds.");
                     await Task.Delay(ThrottleQueryDelay, cancellationToken).ConfigureAwait(false);
                 }
             }

--- a/src/NLU.DevOps.Luis.Shared/LuisNLUTrainClient.cs
+++ b/src/NLU.DevOps.Luis.Shared/LuisNLUTrainClient.cs
@@ -218,7 +218,7 @@ namespace NLU.DevOps.Luis
                 catch (ErrorResponseException ex)
                 when ((int)ex.Response.StatusCode == 429)
                 {
-                    Logger.LogWarning("Received HTTP 429 result from LUIS. Retrying.");
+                    Logger.LogTrace("Received HTTP 429 result from LUIS. Retrying.");
                     await Task.Delay(TrainStatusDelay, cancellationToken).ConfigureAwait(false);
                 }
             }

--- a/src/NLU.DevOps.Luis/LuisTestClient.cs
+++ b/src/NLU.DevOps.Luis/LuisTestClient.cs
@@ -61,7 +61,7 @@ namespace NLU.DevOps.Luis
                 catch (APIErrorException ex)
                 when ((int)ex.Response.StatusCode == 429)
                 {
-                    Logger.LogWarning("Received HTTP 429 result from Cognitive Services. Retrying.");
+                    Logger.LogTrace("Received HTTP 429 result from Cognitive Services. Retrying.");
                     await Task.Delay(ThrottleQueryDelay, cancellationToken).ConfigureAwait(false);
                 }
             }

--- a/src/NLU.DevOps.LuisV3/LuisTestClient.cs
+++ b/src/NLU.DevOps.LuisV3/LuisTestClient.cs
@@ -71,7 +71,7 @@ namespace NLU.DevOps.Luis
                 catch (ErrorException ex)
                 when ((int)ex.Response.StatusCode == 429)
                 {
-                    Logger.LogWarning("Received HTTP 429 result from Cognitive Services. Retrying.");
+                    Logger.LogTrace("Received HTTP 429 result from Cognitive Services. Retrying.");
                     await Task.Delay(ThrottleQueryDelay, cancellationToken).ConfigureAwait(false);
                 }
             }


### PR DESCRIPTION
The frequency of the retries during testing is too high, changing to traces.

Fixes #240