### PR TITLE
Adds configuration to clean version only

### DIFF
--- a/docs/LuisEndpointConfiguration.md
+++ b/docs/LuisEndpointConfiguration.md
@@ -107,7 +107,8 @@ Within an `appsettings.luis.json` file use the following:
 {
   "luisAuthoringKey": "...",
   "luisAuthoringRegion": "westus",
-  "luisAppId": "00000000-0000-0000-0000-000000000000"
+  "luisAppId": "00000000-0000-0000-0000-000000000000",
+  "luisAppCreated": true
 }
 ```
 
@@ -117,6 +118,7 @@ If using environment variables set the values (example shown using Powershell):
 $env:luisAuthoringKey='...'
 $env:luisAuthoringRegion='westus'
 $env:luisAppId='00000000-0000-0000-0000-000000000000'
+$env:luisAppCreated='true'
 ```
 
 Example below uses the export command to create environment variables on a Mac:
@@ -125,9 +127,12 @@ Example below uses the export command to create environment variables on a Mac:
 export luisAuthoringKey='...'
 export luisAuthoringRegion='westus'
 export luisAppId='00000000-0000-0000-0000-000000000000'
+export luisAppCreated='true'
 ```
 
 This will allow you to call the `clean` sub-command for LUIS (see [Tearing down an NLU model](Clean.md) for more details).
+
+If you only wish to delete a specific version trained by NLU.DevOps (see [Configuration for LUIS version](#configuration-for-luis-version)), make sure the [`luisAppCreated`](#luisappcreated) configuration value is not set to `true`.
 
 To simplify the configuration process in continuous integration scenarios, you can use the [`--save-appsettings`](Train.md#-a---save-appsettings) option to save the LUIS app ID generated from a previous call to `train` in a `appsettings.luis.json` file.
 
@@ -136,6 +141,15 @@ Options to consider for tearing down a LUIS model include:
 - [`luisAuthoringKey`](#luisauthoringkey)
 - [`luisAuthoringRegion`](#luisauthoringregion)
 - [`luisAppId`](#luisappid)
+- [`luisAppCreated`](#luisappcreated)
+
+## Configuration for LUIS version
+
+By default, NLU.DevOps will try to publish your LUIS app using version `"0.1.1"`. There are a few configuration values that can be set to create set a specific LUIS version instead.
+
+If you are publishing a specific version, you can simply set the [`luisVersionId`](#luisversionid) configuration value.
+
+If you are setting up a pipeline for CI/CD in Azure DevOps, you may want to consider using the [`luisVersionPrefix`](#luisversionprefix), which will be prepended to the Azure Pipelines build ID, i.e., `$(luisVersionPrefix).$(Build.BuildId)`.
 
 ## Configuration for Azure resource assignment
 
@@ -212,6 +226,11 @@ Required for `test` and `clean`. Optional for `train`; when supplied, the sub-co
 (Optional) Boolean signaling whether to use the LUIS staging endpoint.
 
 Optional for `train` and `test`. When supplied for `train` as `true`, the CLI tool will publish the model to the staging endpoint. When supplied for `test` as `true`, the CLI tool will make requests against the staging endpoint.
+
+### `luisAppCreated`
+(Optional) Boolean signaling whether the LUIS app was created in the current context.
+
+Optional for `clean`. When supplied as `true`, the CLI tool will delete the LUIS app. Otherwise, when supplied as `false`, the CLI tool will only delete the configured LUIS version.
 
 ### `luisSlotName`
 

--- a/src/NLU.DevOps.Luis.Shared/ILuisConfiguration.cs
+++ b/src/NLU.DevOps.Luis.Shared/ILuisConfiguration.cs
@@ -51,6 +51,11 @@ namespace NLU.DevOps.Luis
         bool IsStaging { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the LUIS app was created in the current context.
+        /// </summary>
+        bool AppCreated { get; }
+
+        /// <summary>
         /// Gets the Cognitive Services speech key.
         /// </summary>
         string SpeechKey { get; }

--- a/src/NLU.DevOps.Luis.Shared/ILuisTrainClient.cs
+++ b/src/NLU.DevOps.Luis.Shared/ILuisTrainClient.cs
@@ -31,6 +31,15 @@ namespace NLU.DevOps.Luis
         Task DeleteAppAsync(string appId, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Deletes the LUIS app version.
+        /// </summary>
+        /// <returns>Task to await the delete operation.</returns>
+        /// <param name="appId">LUIS app ID.</param>
+        /// <param name="versionId">LUIS version ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task DeleteVersionAsync(string appId, string versionId, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Gets the training status for the LUIS app version.
         /// </summary>
         /// <returns>Task to await the training status response.</returns>

--- a/src/NLU.DevOps.Luis.Shared/LuisConfiguration.cs
+++ b/src/NLU.DevOps.Luis.Shared/LuisConfiguration.cs
@@ -47,6 +47,8 @@ namespace NLU.DevOps.Luis
         private const string CustomSpeechEndpointTemplate = "https://{0}.stt.speech.microsoft.com/speech/recognition/interactive/cognitiveservices/v1?language={1}&cid={2}&format=detailed";
         private const string SpeechEndpointTemplate = "https://{0}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language={1}&format=detailed";
 
+        private static readonly string LuisAppCreatedConfigurationKey = CamelCase(nameof(LuisNLUTrainClient.LuisAppCreated));
+
         /// <summary>
         /// Initializes a new instance of the <see cref="LuisConfiguration"/> class.
         /// </summary>
@@ -84,6 +86,9 @@ namespace NLU.DevOps.Luis
 
         /// <inheritdoc />
         public bool IsStaging => this.GetConfigurationBoolean(LuisIsStagingConfigurationKey);
+
+        /// <inheritdoc />
+        public bool AppCreated => this.GetConfigurationBoolean(LuisAppCreatedConfigurationKey);
 
         /// <inheritdoc />
         public string SpeechKey => this.EnsureConfigurationString(

--- a/src/NLU.DevOps.Luis.Shared/LuisTrainClient.cs
+++ b/src/NLU.DevOps.Luis.Shared/LuisTrainClient.cs
@@ -59,6 +59,11 @@ namespace NLU.DevOps.Luis
             return this.AuthoringClient.Apps.DeleteAsync(Guid.Parse(appId), cancellationToken: cancellationToken);
         }
 
+        public Task DeleteVersionAsync(string appId, string versionId, CancellationToken cancellationToken)
+        {
+            return this.AuthoringClient.Versions.DeleteAsync(Guid.Parse(appId), versionId, cancellationToken);
+        }
+
         public Task<IList<ModelTrainingInfo>> GetTrainingStatusAsync(string appId, string versionId, CancellationToken cancellationToken)
         {
             return this.AuthoringClient.Train.GetStatusAsync(Guid.Parse(appId), versionId, cancellationToken);

--- a/src/NLU.DevOps.Luis.Tests.Shared/LuisNLUTrainClientTests.cs
+++ b/src/NLU.DevOps.Luis.Tests.Shared/LuisNLUTrainClientTests.cs
@@ -5,6 +5,7 @@ namespace NLU.DevOps.Luis.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -171,12 +172,32 @@ namespace NLU.DevOps.Luis.Tests
         [Test]
         public static async Task CleanupModel()
         {
+            var builder = new LuisNLUTrainClientBuilder
+            {
+                AppCreated = true,
+            };
+
+            using (var luis = builder.Build())
+            {
+                await luis.CleanupAsync().ConfigureAwait(false);
+                var deleteAppRequest = builder.MockLuisTrainClient.Invocations.FirstOrDefault(request => request.Method.Name == nameof(ILuisTrainClient.DeleteAppAsync));
+                var deleteVersionRequest = builder.MockLuisTrainClient.Invocations.FirstOrDefault(request => request.Method.Name == nameof(ILuisTrainClient.DeleteVersionAsync));
+                deleteAppRequest.Should().NotBeNull();
+                deleteVersionRequest.Should().BeNull();
+            }
+        }
+
+        [Test]
+        public static async Task CleanupModelVersionOnly()
+        {
             var builder = new LuisNLUTrainClientBuilder();
             using (var luis = builder.Build())
             {
                 await luis.CleanupAsync().ConfigureAwait(false);
-                var cleanupRequest = builder.MockLuisTrainClient.Invocations.FirstOrDefault(request => request.Method.Name == nameof(ILuisTrainClient.DeleteAppAsync));
-                cleanupRequest.Should().NotBeNull();
+                var deleteAppRequest = builder.MockLuisTrainClient.Invocations.FirstOrDefault(request => request.Method.Name == nameof(ILuisTrainClient.DeleteAppAsync));
+                var deleteVersionRequest = builder.MockLuisTrainClient.Invocations.FirstOrDefault(request => request.Method.Name == nameof(ILuisTrainClient.DeleteVersionAsync));
+                deleteAppRequest.Should().BeNull();
+                deleteVersionRequest.Should().NotBeNull();
             }
         }
 
@@ -371,6 +392,8 @@ namespace NLU.DevOps.Luis.Tests
 
             public string AppName { get; set; } = "test";
 
+            public bool AppCreated { get; set; } = false;
+
             public Mock<ILuisTrainClient> MockLuisTrainClient { get; } = new Mock<ILuisTrainClient>();
 
             public LuisSettings LuisSettings { get; set; } = new LuisSettings();
@@ -385,6 +408,7 @@ namespace NLU.DevOps.Luis.Tests
                     .AddInMemoryCollection(new Dictionary<string, string>
                     {
                         { "luisAppId", this.AppId },
+                        { "luisAppCreated", this.AppCreated.ToString(CultureInfo.InvariantCulture) },
                         { "luisVersionId", this.AppVersion },
                         { "luisAppName", this.AppName },
                     })


### PR DESCRIPTION
We've run into a few cases where the `clean` command inadvertently deletes that was not created within the scope of a single pipeline run, and this was not the desired behavior.

This commit adds functionality so that the LUIS app is only deleted when the `luisAppCreated` configuration value is set to `true`, which will be the case when a new LUIS app is created by the NLU.DevOps tool and the `--save-appsettings` flag is used for training.

Fixes #242