### PR TITLE
Bumps NuGet version to 0.7.0

### DIFF
--- a/src/CommonNuget.props
+++ b/src/CommonNuget.props
@@ -8,6 +8,6 @@
     <PackageProjectUrl>https://github.com/Microsoft/NLU.DevOps</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Microsoft/NLU.DevOps.git</RepositoryUrl>
     <Copyright>© Microsoft Corporation.</Copyright>
-    <Version>0.6.3</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
 </Project>

--- a/src/NLU.DevOps.Core/NLU.DevOps.Core.csproj
+++ b/src/NLU.DevOps.Core/NLU.DevOps.Core.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CodeAnalysis.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>0.6.0</AssemblyVersion>
+    <AssemblyVersion>0.7.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">

--- a/src/NLU.DevOps.Models/NLU.DevOps.Models.csproj
+++ b/src/NLU.DevOps.Models/NLU.DevOps.Models.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CodeAnalysis.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>0.6.0</AssemblyVersion>
+    <AssemblyVersion>0.7.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">


### PR DESCRIPTION
Bumps NuGet version to 0.7.0 in preparation for release.

There is a breaking change for the LUIS v2 and v3 providers. They no longer supports custom settings, only LUIS app templates passed through the `--model-settings` option on the `train` command.