### PR TITLE
Adds strict mode option to compare command

### DIFF
--- a/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
@@ -23,7 +23,8 @@ namespace NLU.DevOps.CommandLine.Compare
             var parameters = CreateParameters(
                 (ConfigurationConstants.ExpectedUtterancesPathKey, options.ExpectedUtterancesPath),
                 (ConfigurationConstants.ActualUtterancesPathKey, options.ActualUtterancesPath),
-                (ConfigurationConstants.TestLabelKey, options.TestLabel));
+                (ConfigurationConstants.TestLabelKey, options.TestLabel),
+                (ConfigurationConstants.StrictKey, options.Strict.ToString(CultureInfo.InvariantCulture)));
 
             var arguments = new List<string> { $"-p:{parameters}" };
             if (options.OutputFolder != null)
@@ -35,7 +36,7 @@ namespace NLU.DevOps.CommandLine.Compare
             {
                 var expectedUtterances = Read<List<JsonLabeledUtterance>>(options.ExpectedUtterancesPath);
                 var actualUtterances = Read<List<JsonLabeledUtterance>>(options.ActualUtterancesPath);
-                var compareResults = TestCaseSource.GetNLUCompareResults(expectedUtterances, actualUtterances);
+                var compareResults = TestCaseSource.GetNLUCompareResults(expectedUtterances, actualUtterances, options.Strict);
                 var metadataPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestMetadataFileName) : TestMetadataFileName;
                 var statisticsPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestStatisticsFileName) : TestStatisticsFileName;
 

--- a/src/NLU.DevOps.CommandLine/Compare/CompareOptions.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareOptions.cs
@@ -22,5 +22,8 @@ namespace NLU.DevOps.CommandLine.Compare
 
         [Option('o', "output-folder", HelpText = "Output path for test results.", Required = false)]
         public string OutputFolder { get; set; }
+
+        [Option("strict", HelpText = "Return false positive results for all unexpected entities.", Required = false)]
+        public bool Strict { get; set; }
     }
 }

--- a/src/NLU.DevOps.Core.Tests/LabeledUtterancePropertyExtensionsTests.cs
+++ b/src/NLU.DevOps.Core.Tests/LabeledUtterancePropertyExtensionsTests.cs
@@ -63,16 +63,6 @@ namespace NLU.DevOps.Core.Tests
             utterance.GetScore().Should().BeNull();
             utterance.GetTextScore().Should().BeNull();
             utterance.GetTimestamp().Should().BeNull();
-            utterance.GetUtteranceId().Should().BeNull();
-        }
-
-        [Test]
-        public static void GetsUtteranceIdFromJson()
-        {
-            var utteranceId = Guid.NewGuid().ToString();
-            var utterance = new JsonLabeledUtterance(null, null, null);
-            utterance.AdditionalProperties.Add("utteranceId", utteranceId);
-            utterance.GetUtteranceId().Should().Be(utteranceId);
         }
 
         [Test]

--- a/src/NLU.DevOps.Core/LabeledUtterancePropertyExtensions.cs
+++ b/src/NLU.DevOps.Core/LabeledUtterancePropertyExtensions.cs
@@ -15,7 +15,6 @@ namespace NLU.DevOps.Core
         private const string ScorePropertyName = "score";
         private const string TextScorePropertyName = "textScore";
         private const string TimestampPropertyName = "timestamp";
-        private const string UtteranceIdPropertyName = "utteranceId";
 
         /// <summary>
         /// Adds a confidence score for the intent label to the labeled utterance.
@@ -121,16 +120,6 @@ namespace NLU.DevOps.Core
         public static T GetProperty<T>(this LabeledUtterance instance, string propertyName)
         {
             return instance.GetPropertyCore<T>(propertyName);
-        }
-
-        /// <summary>
-        /// Gets the utterance identifier for the labeled utterance.
-        /// </summary>
-        /// <param name="instance">Labeled utterance instance.</param>
-        /// <returns>Utterance identifier.</returns>
-        public static string GetUtteranceId(this LabeledUtterance instance)
-        {
-            return instance.GetPropertyCore<string>(UtteranceIdPropertyName);
         }
 
         /// <summary>

--- a/src/NLU.DevOps.ModelPerformance/ConfigurationConstants.cs
+++ b/src/NLU.DevOps.ModelPerformance/ConfigurationConstants.cs
@@ -19,9 +19,9 @@ namespace NLU.DevOps.ModelPerformance
         public const string ActualUtterancesPathKey = "actual";
 
         /// <summary>
-        /// A Boolean value that signals whether to generate text comparison tests.
+        /// A Boolean value that signals whether unexpected utterances should always return false positive results.
         /// </summary>
-        public const string CompareTextKey = "compareText";
+        public const string StrictKey = "strict";
 
         /// <summary>
         /// The test label key.

--- a/src/NLU.DevOps.ModelPerformance/LabeledUtterancePropertyExtensions.cs
+++ b/src/NLU.DevOps.ModelPerformance/LabeledUtterancePropertyExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.ModelPerformance
+{
+    using System;
+    using Core;
+    using Models;
+    using Newtonsoft.Json.Linq;
+
+    internal static class LabeledUtterancePropertyExtensions
+    {
+        private const string UtteranceIdPropertyName = "utteranceId";
+        private const string StrictEntitiesPropertyName = "strictEntities";
+        private const string SpeechFilePropertyName = "speechFile";
+
+        public static string GetUtteranceId(this LabeledUtterance instance)
+        {
+            return instance.GetProperty<string>(UtteranceIdPropertyName);
+        }
+
+        public static string GetSpeechFile(this LabeledUtterance instance)
+        {
+            return instance.GetProperty<string>(SpeechFilePropertyName);
+        }
+
+        public static string[] GetStrictEntities(this LabeledUtterance instance)
+        {
+            return instance.GetProperty<JArray>(StrictEntitiesPropertyName)?.ToObject<string[]>() ?? Array.Empty<string>();
+        }
+    }
+}


### PR DESCRIPTION
Adds `--strict` option for `compare` command, and a declarative way to get false positive entities in case strict mode is not enabled.

Fixes #265