### PR TITLE
Throws when trying to use staging with Speech SDK

### DIFF
--- a/src/NLU.DevOps.Luis/LuisTestClient.cs
+++ b/src/NLU.DevOps.Luis/LuisTestClient.cs
@@ -81,6 +81,11 @@ namespace NLU.DevOps.Luis
 
         private async Task<SpeechLuisResult> RecognizeSpeechWithIntentRecognizerAsync(string speechFile)
         {
+            if (this.LuisConfiguration.IsStaging)
+            {
+                throw new NotSupportedException("Testing LUIS from speech with the Speech SDK does not currently support the LUIS staging endpoint.");
+            }
+
             var speechConfig = SpeechConfig.FromSubscription(this.LuisConfiguration.SpeechKey, this.LuisConfiguration.SpeechRegion);
             using (var audioInput = AudioConfig.FromWavFileInput(speechFile))
             using (var recognizer = new IntentRecognizer(speechConfig, audioInput))


### PR DESCRIPTION
Adds explicit failure when attempting to use the Speech SDK functionality for predicting intents from speech and targeting the LUIS staging endpoint.

Fixes #234