### PR TITLE
Adds CLI option for custom true negative intent

### DIFF
--- a/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
@@ -23,7 +23,8 @@ namespace NLU.DevOps.CommandLine.Compare
             var parameters = CreateParameters(
                 (ConfigurationConstants.ExpectedUtterancesPathKey, options.ExpectedUtterancesPath),
                 (ConfigurationConstants.ActualUtterancesPathKey, options.ActualUtterancesPath),
-                (ConfigurationConstants.TestLabelKey, options.TestLabel));
+                (ConfigurationConstants.TestLabelKey, options.TestLabel),
+                (ConfigurationConstants.StrictKey, options.Strict.ToString(CultureInfo.InvariantCulture)));
 
             var arguments = new List<string> { $"-p:{parameters}" };
             if (options.OutputFolder != null)
@@ -35,7 +36,7 @@ namespace NLU.DevOps.CommandLine.Compare
             {
                 var expectedUtterances = Read<List<JsonLabeledUtterance>>(options.ExpectedUtterancesPath);
                 var actualUtterances = Read<List<JsonLabeledUtterance>>(options.ActualUtterancesPath);
-                var compareResults = TestCaseSource.GetNLUCompareResults(expectedUtterances, actualUtterances);
+                var compareResults = TestCaseSource.GetNLUCompareResults(expectedUtterances, actualUtterances, options.Strict);
                 var metadataPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestMetadataFileName) : TestMetadataFileName;
                 var statisticsPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestStatisticsFileName) : TestStatisticsFileName;
 

--- a/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
@@ -24,7 +24,8 @@ namespace NLU.DevOps.CommandLine.Compare
                 (ConfigurationConstants.ExpectedUtterancesPathKey, options.ExpectedUtterancesPath),
                 (ConfigurationConstants.ActualUtterancesPathKey, options.ActualUtterancesPath),
                 (ConfigurationConstants.TestLabelKey, options.TestLabel),
-                (ConfigurationConstants.StrictKey, options.Strict.ToString(CultureInfo.InvariantCulture)));
+                (ConfigurationConstants.StrictKey, options.Strict.ToString(CultureInfo.InvariantCulture)),
+                (ConfigurationConstants.TrueNegativeIntentKey, options.TrueNegativeIntent));
 
             var arguments = new List<string> { $"-p:{parameters}" };
             if (options.OutputFolder != null)
@@ -34,9 +35,15 @@ namespace NLU.DevOps.CommandLine.Compare
 
             if (options.Metadata)
             {
+                var testOptions = new TestOptions
+                {
+                    Strict = options.Strict,
+                    TrueNegativeIntent = options.TrueNegativeIntent,
+                };
+
                 var expectedUtterances = Read<List<JsonLabeledUtterance>>(options.ExpectedUtterancesPath);
                 var actualUtterances = Read<List<JsonLabeledUtterance>>(options.ActualUtterancesPath);
-                var compareResults = TestCaseSource.GetNLUCompareResults(expectedUtterances, actualUtterances, options.Strict);
+                var compareResults = TestCaseSource.GetNLUCompareResults(expectedUtterances, actualUtterances, testOptions);
                 var metadataPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestMetadataFileName) : TestMetadataFileName;
                 var statisticsPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestStatisticsFileName) : TestStatisticsFileName;
 

--- a/src/NLU.DevOps.CommandLine/Compare/CompareOptions.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareOptions.cs
@@ -25,5 +25,8 @@ namespace NLU.DevOps.CommandLine.Compare
 
         [Option("strict", HelpText = "Return false positive results for all unexpected entities.", Required = false)]
         public bool Strict { get; set; }
+
+        [Option('n', "true-negative-intent", HelpText = "Specifies the name of the intent that used for true negatives.", Required = false)]
+        public string TrueNegativeIntent { get; set; }
     }
 }

--- a/src/NLU.DevOps.CommandLine/Compare/CompareOptions.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareOptions.cs
@@ -22,5 +22,8 @@ namespace NLU.DevOps.CommandLine.Compare
 
         [Option('o', "output-folder", HelpText = "Output path for test results.", Required = false)]
         public string OutputFolder { get; set; }
+
+        [Option("strict", HelpText = "Return false positive results for all unexpected entities.", Required = false)]
+        public bool Strict { get; set; }
     }
 }

--- a/src/NLU.DevOps.Core.Tests/LabeledUtterancePropertyExtensionsTests.cs
+++ b/src/NLU.DevOps.Core.Tests/LabeledUtterancePropertyExtensionsTests.cs
@@ -63,16 +63,6 @@ namespace NLU.DevOps.Core.Tests
             utterance.GetScore().Should().BeNull();
             utterance.GetTextScore().Should().BeNull();
             utterance.GetTimestamp().Should().BeNull();
-            utterance.GetUtteranceId().Should().BeNull();
-        }
-
-        [Test]
-        public static void GetsUtteranceIdFromJson()
-        {
-            var utteranceId = Guid.NewGuid().ToString();
-            var utterance = new JsonLabeledUtterance(null, null, null);
-            utterance.AdditionalProperties.Add("utteranceId", utteranceId);
-            utterance.GetUtteranceId().Should().Be(utteranceId);
         }
 
         [Test]

--- a/src/NLU.DevOps.Core/LabeledUtterancePropertyExtensions.cs
+++ b/src/NLU.DevOps.Core/LabeledUtterancePropertyExtensions.cs
@@ -15,7 +15,6 @@ namespace NLU.DevOps.Core
         private const string ScorePropertyName = "score";
         private const string TextScorePropertyName = "textScore";
         private const string TimestampPropertyName = "timestamp";
-        private const string UtteranceIdPropertyName = "utteranceId";
 
         /// <summary>
         /// Adds a confidence score for the intent label to the labeled utterance.
@@ -121,16 +120,6 @@ namespace NLU.DevOps.Core
         public static T GetProperty<T>(this LabeledUtterance instance, string propertyName)
         {
             return instance.GetPropertyCore<T>(propertyName);
-        }
-
-        /// <summary>
-        /// Gets the utterance identifier for the labeled utterance.
-        /// </summary>
-        /// <param name="instance">Labeled utterance instance.</param>
-        /// <returns>Utterance identifier.</returns>
-        public static string GetUtteranceId(this LabeledUtterance instance)
-        {
-            return instance.GetPropertyCore<string>(UtteranceIdPropertyName);
         }
 
         /// <summary>

--- a/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
@@ -27,7 +27,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void TestToIntentTestCaseExpectingNoneActualDayTime()
         {
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                 new LabeledUtterance("FOO", "None", null),
                 new LabeledUtterance("FOO", "DayTime", null)
@@ -42,7 +42,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void TestToIntentTestCaseActualNoneExpectingDayTime()
         {
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                 new LabeledUtterance("FOO", "DayTime", null),
                 new LabeledUtterance("FOO", "None", null)
@@ -58,7 +58,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         public static void TestToEntityTestCasesMissingAnActualEntity()
         {
             var entity = CreateEntityList("EntityType");
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                 new LabeledUtterance("FOO", "DayTime", entity),
                 new LabeledUtterance("FOO", "DayTime", null)
@@ -75,7 +75,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = CreateEntityList("EntityType");
             var expectedEntity = CreateEntityList("WrongType");
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                  new LabeledUtterance("FOO", "DayTime", expectedEntity),
                  new LabeledUtterance("FOO", "DayTime", actualEntity)
@@ -99,7 +99,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var actualEntity = CreateEntityList("EntityType");
             actualEntity.Add(new Entity("RecognizedEntity", "value", "text", 2));
             var expectedEntity = CreateEntityList("EntityType");
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                 new LabeledUtterance("FOO", "DayTime", expectedEntity),
                 new LabeledUtterance("FOO", "DayTime", actualEntity)
@@ -123,7 +123,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         public static void TestToEntityTestCasesMissingEntityInActualResult()
         {
             var expectedEntity = CreateEntityList("EntityType");
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                 new LabeledUtterance("FOO", "DayTime", expectedEntity),
                 new LabeledUtterance("FOO", "DayTime", null)
@@ -143,7 +143,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = new[] { new Entity("EntityType", "differentEntityValue", "differentMatchedText", 1) };
             var expectedEntity = CreateEntityList("EntityType");
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                  new LabeledUtterance("FOO", "DayTime", expectedEntity),
                  new LabeledUtterance("FOO", "DayTime", actualEntity)
@@ -164,7 +164,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void ToTextTestCaseTrueNegative()
         {
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                 new LabeledUtterance(null, "DayTime", null).WithProperty("speechFile", "speechFile"),
                 new LabeledUtterance(null, "DayTime", null)
@@ -177,7 +177,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void ToTextTestCaseFalseNegative()
         {
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                  new LabeledUtterance("foo", "DayTime", null).WithProperty("speechFile", "speechFile"),
                  new LabeledUtterance(null, "DayTime", null)
@@ -190,7 +190,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void ToTextTestCaseTruePositive()
         {
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                 new LabeledUtterance("foo", "DayTime", null).WithProperty("speechFile", "speechFile"),
                 new LabeledUtterance("FOO", "DayTime", null)
@@ -203,7 +203,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void ToTextTestCaseFalsePositive()
         {
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                 new LabeledUtterance("foo", "DayTime", null).WithProperty("speechFile", "speechFile"),
                 new LabeledUtterance("baz", "DayTime", null)
@@ -228,7 +228,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = new List<Entity> { new Entity("EntityType", ParseEntityValueJson(actualJson), "foo", 1) };
             var expectedEntity = new List<Entity> { new Entity("EntityType", ParseEntityValueJson(expectedJson), "foo", 1) };
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                  new LabeledUtterance("FOO", "DayTime", expectedEntity),
                  new LabeledUtterance("FOO", "DayTime", actualEntity)
@@ -249,7 +249,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
             {
                 var actualEntity = new[] { new Entity("EntityType", 42, "differentMatchedText", 1) };
                 var expectedEntity = new[] { new Entity("EntityType", expectedEntityValue, "differentMatchedText", 1) };
-                var utterances = CreatePair(new[]
+                var utterances = CreateTestInput(new[]
                 {
                      new LabeledUtterance("FOO", "DayTime", expectedEntity),
                      new LabeledUtterance("FOO", "DayTime", actualEntity)
@@ -268,7 +268,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = new[] { new Entity("EntityType", "EntityValue", "differentMatchedText", 1) };
             var expectedEntity = new[] { new Entity("EntityType", null, "differentMatchedText", 2) };
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                  new LabeledUtterance("FOO", "DayTime", expectedEntity),
                  new LabeledUtterance("FOO", "DayTime", actualEntity)
@@ -287,7 +287,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = new[] { new Entity("EntityType", "foo", null, 0) };
             var expectedEntity = new[] { new Entity("EntityType", null, "foo", 0) };
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                  new LabeledUtterance(null, null, expectedEntity),
                  new LabeledUtterance(null, null, actualEntity)
@@ -305,7 +305,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = new[] { new Entity("EntityType", "bar", null, 0) };
             var expectedEntity = new[] { new Entity("EntityType", "bar", "foo", 0) };
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                  new LabeledUtterance(null, null, expectedEntity),
                  new LabeledUtterance(null, null, actualEntity)
@@ -324,7 +324,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = new[] { new Entity("EntityType", "bar", "bar", 0) };
             var expectedEntity = new[] { new Entity("EntityType", "bar", "foo", 0) };
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                  new LabeledUtterance(null, null, expectedEntity),
                  new LabeledUtterance(null, null, actualEntity)
@@ -343,7 +343,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = new[] { new Entity("EntityType", null, "foo", 0) };
             var expectedEntity = new[] { new Entity("EntityType", "bar", "foo", 0) };
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                  new LabeledUtterance(null, null, expectedEntity),
                  new LabeledUtterance(null, null, actualEntity)
@@ -362,7 +362,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var actualEntity = new[] { new Entity("EntityType", "qux", "foo", 0) };
             var expectedEntity = new[] { new Entity("EntityType", "bar", "foo", 0) };
-            var utterances = CreatePair(new[]
+            var utterances = CreateTestInput(new[]
             {
                  new LabeledUtterance(null, null, expectedEntity),
                  new LabeledUtterance(null, null, actualEntity)
@@ -643,7 +643,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
                 new[] { actualUtterance },
-                false);
+                new TestOptions { Strict = false });
             compareResults.Statistics.Entity.TruePositive.Should().Be(0);
             compareResults.Statistics.Entity.TrueNegative.Should().Be(0);
             compareResults.Statistics.Entity.FalsePositive.Should().Be(0);
@@ -657,30 +657,65 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void FalsePositiveEntityWithStrictEntitiesDeclaration()
         {
-            var expectedEntityType = Guid.NewGuid().ToString();
-            var actualEntityType = Guid.NewGuid().ToString();
-            var matchText = Guid.NewGuid().ToString();
-            var expectedEntity = new[] { new Entity(expectedEntityType, null, matchText, 0) };
-            var actualEntity = new[] { new Entity(actualEntityType, null, matchText, 0) };
+            var entityType = Guid.NewGuid().ToString();
+            var expectedMatchText = Guid.NewGuid().ToString();
+            var actualMatchText = Guid.NewGuid().ToString();
+            var expectedEntity = new[] { new Entity(entityType, null, expectedMatchText, 0) };
+            var actualEntity = new[] { new Entity(entityType, null, actualMatchText, 0) };
             var expectedUtterance = new LabeledUtterance(null, null, expectedEntity)
-                .WithProperty("strictEntities", new JArray { actualEntityType });
+                .WithProperty("strictEntities", new JArray { entityType });
             var actualUtterance = new LabeledUtterance(null, null, actualEntity);
             var compareResults = TestCaseSource.GetNLUCompareResults(
                 new[] { expectedUtterance },
                 new[] { actualUtterance },
-                false);
+                new TestOptions { Strict = false });
             compareResults.Statistics.Entity.TruePositive.Should().Be(0);
             compareResults.Statistics.Entity.TrueNegative.Should().Be(0);
             compareResults.Statistics.Entity.FalsePositive.Should().Be(1);
             compareResults.Statistics.Entity.FalseNegative.Should().Be(1);
-            compareResults.Statistics.ByEntityType[expectedEntityType].TruePositive.Should().Be(0);
-            compareResults.Statistics.ByEntityType[expectedEntityType].TrueNegative.Should().Be(0);
-            compareResults.Statistics.ByEntityType[expectedEntityType].FalsePositive.Should().Be(0);
-            compareResults.Statistics.ByEntityType[expectedEntityType].FalseNegative.Should().Be(1);
-            compareResults.Statistics.ByEntityType[actualEntityType].TruePositive.Should().Be(0);
-            compareResults.Statistics.ByEntityType[actualEntityType].TrueNegative.Should().Be(0);
-            compareResults.Statistics.ByEntityType[actualEntityType].FalsePositive.Should().Be(1);
-            compareResults.Statistics.ByEntityType[actualEntityType].FalseNegative.Should().Be(0);
+            compareResults.Statistics.ByEntityType[entityType].TruePositive.Should().Be(0);
+            compareResults.Statistics.ByEntityType[entityType].TrueNegative.Should().Be(0);
+            compareResults.Statistics.ByEntityType[entityType].FalsePositive.Should().Be(1);
+            compareResults.Statistics.ByEntityType[entityType].FalseNegative.Should().Be(1);
+        }
+
+        [Test]
+        [TestCase("foo", "foo", 0, 1, 0, 0)]
+        [TestCase(null, null, 0, 1, 0, 0)]
+        [TestCase(null, "None", 0, 0, 1, 0)]
+        [TestCase("None", null, 0, 0, 0, 1)]
+        [TestCase(null, "foo", 0, 1, 0, 0)]
+        [TestCase("None", "foo", 0, 0, 0, 1)]
+        [TestCase("foo", "bar", 0, 0, 1, 0)]
+        [TestCase("foo", null, 0, 1, 0, 0)]
+        [TestCase("foo", "None", 0, 0, 1, 0)]
+        public static void CustomTrueNegativeIntent(
+            string expected,
+            string actual,
+            int truePositive,
+            int trueNegative,
+            int falsePositive,
+            int falseNegative)
+        {
+            var expectedUtterance = new LabeledUtterance(null, expected, null);
+            var actualUtterance = new LabeledUtterance(null, actual, null);
+            var compareResults = TestCaseSource.GetNLUCompareResults(
+                new[] { expectedUtterance },
+                new[] { actualUtterance },
+                new TestOptions { TrueNegativeIntent = "foo" });
+            compareResults.Statistics.Intent.TruePositive.Should().Be(truePositive);
+            compareResults.Statistics.Intent.TrueNegative.Should().Be(trueNegative);
+            compareResults.Statistics.Intent.FalsePositive.Should().Be(falsePositive);
+            compareResults.Statistics.Intent.FalseNegative.Should().Be(falseNegative);
+            if (expected != null && expected != "foo")
+            {
+                compareResults.Statistics.ByIntent[expected].TruePositive.Should().Be(truePositive);
+                compareResults.Statistics.ByIntent[expected].FalseNegative.Should().Be(falseNegative);
+            }
+            else if (actual != null && actual != "foo")
+            {
+                compareResults.Statistics.ByIntent[actual].FalsePositive.Should().Be(falsePositive);
+            }
         }
 
         private static List<Entity> CreateEntityList(string type)
@@ -698,9 +733,9 @@ namespace NLU.DevOps.ModelPerformance.Tests
             return json != null ? JToken.Parse(json) : null;
         }
 
-        private static TestCaseSource.LabeledUtterancePair CreatePair(params LabeledUtterance[] pair)
+        private static TestCaseSource.LabeledUtteranceTestInput CreateTestInput(params LabeledUtterance[] pair)
         {
-            return new TestCaseSource.LabeledUtterancePair(string.Empty, pair[0], pair[1]);
+            return new TestCaseSource.LabeledUtteranceTestInput(string.Empty, pair[0], pair[1], null);
         }
     }
 }

--- a/src/NLU.DevOps.ModelPerformance/ConfigurationConstants.cs
+++ b/src/NLU.DevOps.ModelPerformance/ConfigurationConstants.cs
@@ -19,9 +19,9 @@ namespace NLU.DevOps.ModelPerformance
         public const string ActualUtterancesPathKey = "actual";
 
         /// <summary>
-        /// A Boolean value that signals whether to generate text comparison tests.
+        /// A Boolean value that signals whether unexpected utterances should always return false positive results.
         /// </summary>
-        public const string CompareTextKey = "compareText";
+        public const string StrictKey = "strict";
 
         /// <summary>
         /// The test label key.

--- a/src/NLU.DevOps.ModelPerformance/ConfigurationConstants.cs
+++ b/src/NLU.DevOps.ModelPerformance/ConfigurationConstants.cs
@@ -27,5 +27,10 @@ namespace NLU.DevOps.ModelPerformance
         /// The test label key.
         /// </summary>
         public const string TestLabelKey = "testLabel";
+
+        /// <summary>
+        /// The intent name used for true negative results.
+        /// </summary>
+        public const string TrueNegativeIntentKey = "trueNegativeIntent";
     }
 }

--- a/src/NLU.DevOps.ModelPerformance/LabeledUtterancePropertyExtensions.cs
+++ b/src/NLU.DevOps.ModelPerformance/LabeledUtterancePropertyExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.ModelPerformance
+{
+    using System;
+    using Core;
+    using Models;
+    using Newtonsoft.Json.Linq;
+
+    internal static class LabeledUtterancePropertyExtensions
+    {
+        private const string UtteranceIdPropertyName = "utteranceId";
+        private const string StrictEntitiesPropertyName = "strictEntities";
+        private const string SpeechFilePropertyName = "speechFile";
+
+        public static string GetUtteranceId(this LabeledUtterance instance)
+        {
+            return instance.GetProperty<string>(UtteranceIdPropertyName);
+        }
+
+        public static string GetSpeechFile(this LabeledUtterance instance)
+        {
+            return instance.GetProperty<string>(SpeechFilePropertyName);
+        }
+
+        public static string[] GetStrictEntities(this LabeledUtterance instance)
+        {
+            return instance.GetProperty<JArray>(StrictEntitiesPropertyName)?.ToObject<string[]>() ?? Array.Empty<string>();
+        }
+    }
+}

--- a/src/NLU.DevOps.ModelPerformance/TestOptions.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestOptions.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.ModelPerformance
+{
+    /// <summary>
+    /// Test options for NLU results validation.
+    /// </summary>
+    public class TestOptions
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether strict mode is enabled.
+        /// </summary>
+        /// <remarks>
+        /// When <code>true</code>, always generates false
+        /// positive test results for unexpected entities.
+        /// </remarks>
+        public bool Strict { get; set; }
+
+        /// <summary>
+        /// Gets or sets the true negative intent name.
+        /// </summary>
+        public string TrueNegativeIntent { get; set; }
+    }
+}


### PR DESCRIPTION
Adds the `-n, --true-negative-intent` option to the `compare` command, which allows you to customize the intent name that will trigger true negative intents.

Fixes #211