### PR TITLE
Adds option to compare NLU results to baseline

### DIFF
--- a/docs/Analyze.md
+++ b/docs/Analyze.md
@@ -61,7 +61,7 @@ For example, the following is likely to generate a false positive entity result 
 
 ### `benchmark`
 
-The `benchmark` command will generate JSON output for the confusion matrix with the following format:
+The `benchmark` command will output a JSON file called `metadata.json` for the confusion matrix with the following format:
 ```plaintext
 [
   {
@@ -80,7 +80,29 @@ The `benchmark` command will generate JSON output for the confusion matrix with 
 ]
 ```
 
-The results generated for the `benchmark` command are equivalent to the `compare` command for intents. For entities, `benchmark` generates all false positive results for unexpected entities by default, except in cases where they are explicity ignored.
+It also generates a much smaller high-level summary of confusion matrix results grouped by intent and entity type, called `statistics.json`:
+```plaintext
+{
+  "intent": [
+    7, /* true positive */
+    4, /* true negative */
+    1, /* false positive */
+    3  /* false negative */
+  ],
+  "entity": [ 2, 10, 1, 2 ],
+  "byIntent": {
+    "PlayMusic": [ 5, 0, 1, 1 ],
+    "Skip": [ 2, 0, 0, 2 ]
+  },
+  "byEntityType": {
+    "Genre": [ 1, 0, 0, 2 ]
+  }
+}
+```
+
+The `metadata.json` output is useful for reviewing fine-grained details of NLU tests, whereas the `statistics.json`, given it's more compact representation, is useful for comparing course-grained measurements (e.g., precision and recall) over time across multiple test runs.
+
+The confusion matrix results generated for the `benchmark` command are equivalent to the `compare` command for intents. For entities, `benchmark` generates all false positive results for unexpected entities by default, except in cases where they are explicity ignored.
 
 For example, the following would not generate a false positive result for `genre`, as even though it was not declared in `entities`, the entity type was listed in the `ignoreEntities` property.
 ```json

--- a/src/NLU.DevOps.CommandLine/Benchmark/BenchmarkCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Benchmark/BenchmarkCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace NLU.DevOps.CommandLine.Benchmark
@@ -27,7 +27,9 @@ namespace NLU.DevOps.CommandLine.Benchmark
 
             Write(metadataPath, compareResults.TestCases);
             File.WriteAllText(statisticsPath, JObject.FromObject(compareResults.Statistics).ToString());
-            compareResults.PrintResults();
+
+            var baseline = options.BaselineResultsPath != null ? Read<NLUStatistics>(options.BaselineResultsPath) : null;
+            compareResults.PrintResults(baseline);
 
             return 0;
         }

--- a/src/NLU.DevOps.CommandLine/Benchmark/BenchmarkOptions.cs
+++ b/src/NLU.DevOps.CommandLine/Benchmark/BenchmarkOptions.cs
@@ -3,7 +3,6 @@
 
 namespace NLU.DevOps.CommandLine.Benchmark
 {
-    using Compare;
     using global::CommandLine;
 
     [Verb("benchmark", HelpText = "Compute confusion matrix results.")]

--- a/src/NLU.DevOps.Lex/LexNLUClientFactory.cs
+++ b/src/NLU.DevOps.Lex/LexNLUClientFactory.cs
@@ -12,7 +12,6 @@ namespace NLU.DevOps.Lex
     using Amazon.Runtime;
     using Microsoft.Extensions.Configuration;
     using Models;
-    using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
     /// <summary>

--- a/src/NLU.DevOps.ModelPerformance.Tests/ConfusionMatrixConverterTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/ConfusionMatrixConverterTests.cs
@@ -3,6 +3,7 @@
 
 namespace NLU.DevOps.ModelPerformance.Tests
 {
+    using System;
     using FluentAssertions;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
@@ -11,6 +12,41 @@ namespace NLU.DevOps.ModelPerformance.Tests
     [TestFixture]
     internal static class ConfusionMatrixConverterTests
     {
+        [Test]
+        public static void ReadsNullValue()
+        {
+            var converter = new ConfusionMatrixConverter();
+            var nullResult = JsonConvert.DeserializeObject<ConfusionMatrix>("null", converter);
+            var undefinedResult = JsonConvert.DeserializeObject<ConfusionMatrix>("undefined", converter);
+            nullResult.Should().BeNull();
+            undefinedResult.Should().BeNull();
+        }
+
+        [Test]
+        public static void ReadsCorrectValue()
+        {
+            var converter = new ConfusionMatrixConverter();
+            var result = JsonConvert.DeserializeObject<ConfusionMatrix>("[ 1, 2, 3, 4 ]", converter);
+            result.TruePositive.Should().Be(1);
+            result.TrueNegative.Should().Be(2);
+            result.FalsePositive.Should().Be(3);
+            result.FalseNegative.Should().Be(4);
+        }
+
+        [Test]
+        [TestCase("42")]
+        [TestCase("{}")]
+        [TestCase("{\"truePositive\": 42}")]
+        [TestCase("[42]")]
+        [TestCase("[1,2,3,4,5]")]
+        [TestCase("[1,2,3,4.1]")]
+        public static void ReadThrowsOnInvalidJson(string invalidJson)
+        {
+            var converter = new ConfusionMatrixConverter();
+            Action deserialize = () => JsonConvert.DeserializeObject<ConfusionMatrix>(invalidJson, converter);
+            deserialize.Should().Throw<InvalidOperationException>();
+        }
+
         [Test]
         public static void WritesNullValue()
         {

--- a/src/NLU.DevOps.ModelPerformance.Tests/NLUAccuracyTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/NLUAccuracyTests.cs
@@ -12,40 +12,19 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void AccuracyWithAllZeroes()
         {
-            ConfusionMatrix cm = new ConfusionMatrix(0, 0, 0, 0);
-
-            var result = cm.CalcAccuracy();
-
-            result.Count.Should().Be(3);
-            result[0].Should().Be(0);
-            result[1].Should().Be(0);
-            result[2].Should().Be(0);
+            var matrix = new ConfusionMatrix(0, 0, 0, 0);
+            matrix.Precision().Should().Be(0);
+            matrix.Recall().Should().Be(0);
+            matrix.F1().Should().Be(0);
         }
 
         [Test]
         public static void AccuracyWithValues()
         {
-            ConfusionMatrix cm = new ConfusionMatrix(13, 0, 10, 45);
-
-            var result = cm.CalcAccuracy();
-
-            result.Count.Should().Be(3);
-            result[0].Should().Be(0.5652);
-            result[1].Should().Be(0.2241);
-            result[2].Should().Be(0.3210);
-        }
-
-        [Test]
-        public static void AccuracyWithValuesWithdRoundingDecimal()
-        {
-            ConfusionMatrix cm = new ConfusionMatrix(13, 0, 10, 45);
-
-            var result = cm.CalcAccuracy(5);
-
-            result.Count.Should().Be(3);
-            result[0].Should().Be(0.56522);
-            result[1].Should().Be(0.22414);
-            result[2].Should().Be(0.32099);
+            var matrix = new ConfusionMatrix(13, 0, 10, 45);
+            matrix.Precision().Should().BeApproximately(0.5652, 0.0001);
+            matrix.Recall().Should().BeApproximately(0.2241, 0.0001);
+            matrix.F1().Should().BeApproximately(0.3210, 0.0001);
         }
     }
 }

--- a/src/NLU.DevOps.ModelPerformance.Tests/NLUAccuracyTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/NLUAccuracyTests.cs
@@ -16,6 +16,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
             matrix.Precision().Should().Be(0);
             matrix.Recall().Should().Be(0);
             matrix.F1().Should().Be(0);
+            matrix.Total().Should().Be(0);
         }
 
         [Test]
@@ -25,6 +26,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
             matrix.Precision().Should().BeApproximately(0.5652, 0.0001);
             matrix.Recall().Should().BeApproximately(0.2241, 0.0001);
             matrix.F1().Should().BeApproximately(0.3210, 0.0001);
+            matrix.Total().Should().Be(68);
         }
     }
 }

--- a/src/NLU.DevOps.ModelPerformance/ConfusionMatrix.cs
+++ b/src/NLU.DevOps.ModelPerformance/ConfusionMatrix.cs
@@ -31,6 +31,11 @@ namespace NLU.DevOps.ModelPerformance
         }
 
         /// <summary>
+        /// Gets the default confusion matrix.
+        /// </summary>
+        public static ConfusionMatrix Default { get; } = new ConfusionMatrix(0, 0, 0, 0);
+
+        /// <summary>
         /// Gets the true positive count.
         /// </summary>
         public int TruePositive { get; }

--- a/src/NLU.DevOps.ModelPerformance/NLUAccuracy.cs
+++ b/src/NLU.DevOps.ModelPerformance/NLUAccuracy.cs
@@ -26,50 +26,64 @@ namespace NLU.DevOps.ModelPerformance
             var allIntentsPrecision = Print(compareResults.Statistics.Intent.Precision(), baseline?.Intent.Precision());
             var allIntentsRecall = Print(compareResults.Statistics.Intent.Recall(), baseline?.Intent.Recall());
             var allIntentsF1 = Print(compareResults.Statistics.Intent.F1(), baseline?.Intent.F1());
+            var allIntentsTotal = Print(compareResults.Statistics.Intent.Total(), baseline?.Intent.Total(), 0);
+            var allIntentsFP = Print(compareResults.Statistics.Intent.FalsePositive, baseline?.Intent.FalsePositive, 0);
 
-            Console.WriteLine("# Intents results");
+            Console.WriteLine("## Intents Results");
 
-            var intentTable = new ConsoleTable("Intent", "Precision", "Recall", "F1");
-            intentTable.AddRow("*", allIntentsPrecision, allIntentsRecall, allIntentsF1);
+            var intentTable = new ConsoleTable("Intent", "Precision", "Recall", "F1", "Total", "FP");
+            intentTable.AddRow("*", allIntentsPrecision, allIntentsRecall, allIntentsF1, allIntentsTotal, allIntentsFP);
 
-            compareResults.Statistics.ByIntent.ToList().ForEach(intentItem =>
-            {
-                var baselineResults = default(ConfusionMatrix);
-                if (baseline != null && !baseline.ByIntent.TryGetValue(intentItem.Key, out baselineResults))
+            compareResults.Statistics.ByIntent
+                .OrderBy(intentItem => intentItem.Key)
+                .ToList()
+                .ForEach(intentItem =>
                 {
-                    baselineResults = ConfusionMatrix.Default;
-                }
+                    var baselineResults = default(ConfusionMatrix);
+                    if (baseline != null && !baseline.ByIntent.TryGetValue(intentItem.Key, out baselineResults))
+                    {
+                        baselineResults = ConfusionMatrix.Default;
+                    }
 
-                var intentPrecision = Print(intentItem.Value.Precision(), baselineResults?.Precision());
-                var intentRecall = Print(intentItem.Value.Recall(), baselineResults?.Recall());
-                var intentF1 = Print(intentItem.Value.F1(), baselineResults?.F1());
-                intentTable.AddRow(intentItem.Key, intentPrecision, intentRecall, intentF1);
-            });
+                    var intentPrecision = Print(intentItem.Value.Precision(), baselineResults?.Precision());
+                    var intentRecall = Print(intentItem.Value.Recall(), baselineResults?.Recall());
+                    var intentF1 = Print(intentItem.Value.F1(), baselineResults?.F1());
+                    var intentTotal = Print(intentItem.Value.Total(), baselineResults?.Total(), 0);
+                    var intentFP = Print(intentItem.Value.FalsePositive, baselineResults?.FalsePositive, 0);
+                    intentTable.AddRow(intentItem.Key, intentPrecision, intentRecall, intentF1, intentTotal, intentFP);
+                });
 
             intentTable.Write(Format.MarkDown);
 
             var allEntitiesPrecision = Print(compareResults.Statistics.Entity.Precision(), baseline?.Entity.Precision());
             var allEntitiesRecall = Print(compareResults.Statistics.Entity.Recall(), baseline?.Entity.Recall());
             var allEntitiesF1 = Print(compareResults.Statistics.Entity.F1(), baseline?.Entity.F1());
+            var allEntitiesTotal = Print(compareResults.Statistics.Entity.Total(), baseline?.Entity.Total(), 0);
+            var allEntitiesFP = Print(compareResults.Statistics.Entity.FalsePositive, baseline?.Entity.FalsePositive, 0);
 
-            Console.WriteLine("# Entity results");
+            Console.WriteLine("## Entity Results");
 
-            var entityTable = new ConsoleTable("Entity", "Precision", "Recall", "F1");
-            entityTable.AddRow("*", allEntitiesPrecision, allEntitiesRecall, allEntitiesF1);
+            var entityTable = new ConsoleTable("Entity", "Precision", "Recall", "F1", "Total", "FP");
+            entityTable.AddRow("*", allEntitiesPrecision, allEntitiesRecall, allEntitiesF1, allEntitiesTotal, allEntitiesFP);
 
-            compareResults.Statistics.ByEntityType.ToList().ForEach(entityItem =>
-            {
-                var baselineResults = default(ConfusionMatrix);
-                if (baseline != null && !baseline.ByEntityType.TryGetValue(entityItem.Key, out baselineResults))
+            compareResults.Statistics.ByEntityType
+                .OrderBy(entityItem => entityItem.Key)
+                .ToList()
+                .ForEach(entityItem =>
                 {
-                    baselineResults = ConfusionMatrix.Default;
-                }
+                    var baselineResults = default(ConfusionMatrix);
+                    if (baseline != null && !baseline.ByEntityType.TryGetValue(entityItem.Key, out baselineResults))
+                    {
+                        baselineResults = ConfusionMatrix.Default;
+                    }
 
-                var entityPrecision = Print(entityItem.Value.Precision(), baselineResults?.Precision());
-                var entityRecall = Print(entityItem.Value.Recall(), baselineResults?.Recall());
-                var entityF1 = Print(entityItem.Value.F1(), baselineResults?.F1());
-                entityTable.AddRow(entityItem.Key, entityPrecision, entityRecall, entityF1);
-            });
+                    var entityPrecision = Print(entityItem.Value.Precision(), baselineResults?.Precision());
+                    var entityRecall = Print(entityItem.Value.Recall(), baselineResults?.Recall());
+                    var entityF1 = Print(entityItem.Value.F1(), baselineResults?.F1());
+                    var entityTotal = Print(entityItem.Value.Total(), baselineResults?.Total(), 0);
+                    var entityFP = Print(entityItem.Value.FalsePositive, baselineResults?.FalsePositive, 0);
+                    entityTable.AddRow(entityItem.Key, entityPrecision, entityRecall, entityF1, entityTotal, entityFP);
+                });
 
             entityTable.Write(Format.MarkDown);
 
@@ -77,30 +91,30 @@ namespace NLU.DevOps.ModelPerformance
         }
 
         /// <summary>
-        /// Calculates the precision from a confusion matrix
+        /// Calculates the precision from a confusion matrix.
         /// </summary>
-        /// <param name="matrix">confusion matrix metrics</param>
-        /// <returns>The precision result</returns>
+        /// <param name="matrix">Confusion matrix.</param>
+        /// <returns>Precision value.</returns>
         internal static double Precision(this ConfusionMatrix matrix)
         {
             return Divide(matrix.TruePositive, matrix.TruePositive + matrix.FalsePositive);
         }
 
         /// <summary>
-        ///  Calculates the recall from a confusion matrix
+        /// Calculates the recall from a confusion matrix.
         /// </summary>
-        /// <param name="matrix"> confusin matrix metrics</param>
-        /// <returns> The recall result</returns>
+        /// <param name="matrix">Confusion matrix.</param>
+        /// <returns>Recall value.</returns>
         internal static double Recall(this ConfusionMatrix matrix)
         {
             return Divide(matrix.TruePositive, matrix.TruePositive + matrix.FalseNegative);
         }
 
         /// <summary>
-        /// Calculates the f1 score from a confusion matrix
+        /// Calculates the F<sub>1</sub> score from a confusion matrix.
         /// </summary>
-        /// <param name="matrix"> confusion matrix metrics</param>
-        /// <returns> the f1 result</returns>
+        /// <param name="matrix">Confusion matrix.</param>
+        /// <returns>F<sub>1</sub> score.</returns>
         internal static double F1(this ConfusionMatrix matrix)
         {
             var precision = matrix.Precision();
@@ -110,37 +124,55 @@ namespace NLU.DevOps.ModelPerformance
         }
 
         /// <summary>
-        /// Divides the dividend input by the divisor
+        /// Calculates total count for the confusion matrix.
         /// </summary>
-        /// <param name="dividend"> The dividend in the division</param>
-        /// <param name="divisor"> The divisor in the division</param>
-        /// <returns>The division result</returns>
+        /// <param name="matrix">Confusion matrix.</param>
+        /// <returns>Total count.</returns>
+        internal static int Total(this ConfusionMatrix matrix)
+        {
+            return matrix.TruePositive + matrix.TrueNegative + matrix.FalsePositive + matrix.FalseNegative;
+        }
+
+        /// <summary>
+        /// Divides the dividend input by the divisor.
+        /// </summary>
+        /// <param name="dividend"> Dividend in the division.</param>
+        /// <param name="divisor"> Divisor in the division.</param>
+        /// <returns>Division result.</returns>
         private static double Divide(double dividend, int divisor)
         {
             return divisor != 0 ? dividend / divisor : 0;
         }
 
         /// <summary>
-        /// Prints the confusion table for intents
+        /// Prints the confusion table for intents.
         /// </summary>
-        /// <param name="testCases"> The calculated metadata results</param>
+        /// <param name="testCases"> Test cases.</param>
         private static void PrintIntentConfusionTable(IReadOnlyList<TestCase> testCases)
         {
+            bool isFalsePositiveIntent(TestCase testCase)
+            {
+                return testCase.TargetKind == ComparisonTargetKind.Intent
+                    && testCase.ResultKind == ConfusionMatrixResultKind.FalsePositive;
+            }
+
+            (string Expected, string Actual) keySelector(TestCase testCase)
+            {
+                return (testCase.ExpectedUtterance.Intent, testCase.ActualUtterance.Intent);
+            }
+
             var falsePositiveIntents = testCases
-                                       .Where(testCase => testCase.TargetKind == ComparisonTargetKind.Intent
-                                                          && testCase.ResultKind == ConfusionMatrixResultKind.FalsePositive)
-                                       .GroupBy(testCase => (testCase.ExpectedUtterance.Intent, testCase.ActualUtterance.Intent))
-                                       .ToDictionary(
-                                           group => group.Key,
-                                           group => group.Count())
-                                       .OrderByDescending(group => group.Value);
+                .Where(isFalsePositiveIntent)
+                .GroupBy(keySelector)
+                .ToDictionary(group => group.Key, group => group.Count())
+                .OrderByDescending(group => group.Value);
 
-            Console.WriteLine("# Intent Confusion Matrix");
+            Console.WriteLine("## Intent Confusion Matrix");
 
-            var confusionMatrix = new ConsoleTable("Expected intent", "Actual Intent", "FP");
+            var confusionMatrix = new ConsoleTable("Expected", "Actual", "FP");
             falsePositiveIntents.ToList().ForEach(kvp =>
             {
-                confusionMatrix.AddRow(kvp.Key.Item1, kvp.Key.Item2, kvp.Value);
+                confusionMatrix.AddRow(kvp.Key.Expected, kvp.Key.Actual, kvp.Value);
             });
 
             confusionMatrix.Write(Format.MarkDown);
@@ -151,12 +183,14 @@ namespace NLU.DevOps.ModelPerformance
         /// </summary>
         /// <param name="current">Current value.</param>
         /// <param name="baseline">Baseline value.</param>
+        /// <param name="precision">Rounding precision.</param>
         /// <returns>Printed value and difference with baseline.</returns>
-        private static string Print(double current, double? baseline)
+        private static string Print(double current, double? baseline, int precision = 3)
         {
+            var format = $"0.{string.Join(string.Empty, Enumerable.Repeat("0", precision))}";
             return baseline.HasValue
-                ? string.Format(CultureInfo.CurrentCulture, "{0:0.0000} ({1:0.0000})", current, current - baseline)
-                : string.Format(CultureInfo.CurrentCulture, "{0:0.0000}", current);
+                ? string.Format(CultureInfo.CurrentCulture, $"{{0:{format}}} ({{1:{format}}})", current, current - baseline)
+                : string.Format(CultureInfo.CurrentCulture, $"{{0:{format}}}", current);
         }
     }
 }

--- a/src/NLU.DevOps.ModelPerformance/NLUAccuracy.cs
+++ b/src/NLU.DevOps.ModelPerformance/NLUAccuracy.cs
@@ -5,6 +5,7 @@ namespace NLU.DevOps.ModelPerformance
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using ConsoleTables;
 
@@ -15,58 +16,97 @@ namespace NLU.DevOps.ModelPerformance
     public static class NLUAccuracy
     {
         /// <summary>
-        /// Calculates Precision, Recall and F1 Score
-        /// </summary>
-        /// <param name="cm">confusion matrix metrics</param>
-        /// <param name="roundingplace"> Specifies the number of digits after the decimal point</param>
-        /// <returns>List that contains the results calculated</returns>
-        public static List<double> CalcAccuracy(this ConfusionMatrix cm, int roundingplace = 4)
-        {
-            var metrics = new List<double>
-            {
-                Math.Round(cm.Precision(), roundingplace),
-                Math.Round(cm.Recall(), roundingplace),
-                Math.Round(cm.F1(), roundingplace)
-            };
-            return metrics;
-        }
-
-        /// <summary>
         /// Prints to the console the intents, entities performance results
         /// and a confusion table for intents
         /// </summary>
         /// <param name="compareResults"> The comparison results for intents and entities</param>
-        public static void PrintResults(this NLUCompareResults compareResults)
+        /// <param name="baseline">The baseline results the results are benchmarked against.</param>
+        public static void PrintResults(this NLUCompareResults compareResults, NLUStatistics baseline)
         {
-            var intentAverageResults = compareResults.Statistics.Intent.CalcAccuracy();
-            Console.WriteLine("== Intents results == ");
+            var allIntentsPrecision = Print(compareResults.Statistics.Intent.Precision(), baseline?.Intent.Precision());
+            var allIntentsRecall = Print(compareResults.Statistics.Intent.Recall(), baseline?.Intent.Recall());
+            var allIntentsF1 = Print(compareResults.Statistics.Intent.F1(), baseline?.Intent.F1());
+
+            Console.WriteLine("# Intents results");
+
             var intentTable = new ConsoleTable("Intent", "Precision", "Recall", "F1");
-            intentTable.AddRow("*", intentAverageResults[0], intentAverageResults[1], intentAverageResults[2]);
+            intentTable.AddRow("*", allIntentsPrecision, allIntentsRecall, allIntentsF1);
 
-            compareResults.Statistics.ByIntent.ToList().ForEach(kvp =>
+            compareResults.Statistics.ByIntent.ToList().ForEach(intentItem =>
             {
-                // Calculating accuracy numbers and rounding up the result values for each intent
-                var results = kvp.Value.CalcAccuracy();
-                intentTable.AddRow(kvp.Key, results[0], results[1], results[2]);
+                var baselineResults = default(ConfusionMatrix);
+                if (baseline != null && !baseline.ByIntent.TryGetValue(intentItem.Key, out baselineResults))
+                {
+                    baselineResults = ConfusionMatrix.Default;
+                }
+
+                var intentPrecision = Print(intentItem.Value.Precision(), baselineResults?.Precision());
+                var intentRecall = Print(intentItem.Value.Recall(), baselineResults?.Recall());
+                var intentF1 = Print(intentItem.Value.F1(), baselineResults?.F1());
+                intentTable.AddRow(intentItem.Key, intentPrecision, intentRecall, intentF1);
             });
 
-            intentTable.Write();
+            intentTable.Write(Format.MarkDown);
 
-            var entityAverageResults = compareResults.Statistics.Entity.CalcAccuracy();
-            Console.WriteLine("== Entity results == ");
+            var allEntitiesPrecision = Print(compareResults.Statistics.Entity.Precision(), baseline?.Entity.Precision());
+            var allEntitiesRecall = Print(compareResults.Statistics.Entity.Recall(), baseline?.Entity.Recall());
+            var allEntitiesF1 = Print(compareResults.Statistics.Entity.F1(), baseline?.Entity.F1());
+
+            Console.WriteLine("# Entity results");
+
             var entityTable = new ConsoleTable("Entity", "Precision", "Recall", "F1");
-            entityTable.AddRow("*", entityAverageResults[0], entityAverageResults[1], entityAverageResults[2]);
+            entityTable.AddRow("*", allEntitiesPrecision, allEntitiesRecall, allEntitiesF1);
 
-            compareResults.Statistics.ByEntityType.ToList().ForEach(kvp =>
+            compareResults.Statistics.ByEntityType.ToList().ForEach(entityItem =>
             {
-                // Calculating accuracy numbers and rounding up the result values for each entity
-                var entityResults = kvp.Value.CalcAccuracy().ToList();
-                entityTable.AddRow(kvp.Key, entityResults[0], entityResults[1], entityResults[2]);
+                var baselineResults = default(ConfusionMatrix);
+                if (baseline != null && !baseline.ByEntityType.TryGetValue(entityItem.Key, out baselineResults))
+                {
+                    baselineResults = ConfusionMatrix.Default;
+                }
+
+                var entityPrecision = Print(entityItem.Value.Precision(), baselineResults?.Precision());
+                var entityRecall = Print(entityItem.Value.Recall(), baselineResults?.Recall());
+                var entityF1 = Print(entityItem.Value.F1(), baselineResults?.F1());
+                entityTable.AddRow(entityItem.Key, entityPrecision, entityRecall, entityF1);
             });
 
-            entityTable.Write();
+            entityTable.Write(Format.MarkDown);
 
             PrintIntentConfusionTable(compareResults.TestCases);
+        }
+
+        /// <summary>
+        /// Calculates the precision from a confusion matrix
+        /// </summary>
+        /// <param name="matrix">confusion matrix metrics</param>
+        /// <returns>The precision result</returns>
+        internal static double Precision(this ConfusionMatrix matrix)
+        {
+            return Divide(matrix.TruePositive, matrix.TruePositive + matrix.FalsePositive);
+        }
+
+        /// <summary>
+        ///  Calculates the recall from a confusion matrix
+        /// </summary>
+        /// <param name="matrix"> confusin matrix metrics</param>
+        /// <returns> The recall result</returns>
+        internal static double Recall(this ConfusionMatrix matrix)
+        {
+            return Divide(matrix.TruePositive, matrix.TruePositive + matrix.FalseNegative);
+        }
+
+        /// <summary>
+        /// Calculates the f1 score from a confusion matrix
+        /// </summary>
+        /// <param name="matrix"> confusion matrix metrics</param>
+        /// <returns> the f1 result</returns>
+        internal static double F1(this ConfusionMatrix matrix)
+        {
+            var precision = matrix.Precision();
+            var recall = matrix.Recall();
+            var denominator = precision + recall;
+            return Math.Abs(denominator) > double.Epsilon ? 2 * (precision * recall) / denominator : 0;
         }
 
         /// <summary>
@@ -78,39 +118,6 @@ namespace NLU.DevOps.ModelPerformance
         private static double Divide(double dividend, int divisor)
         {
             return divisor != 0 ? dividend / divisor : 0;
-        }
-
-        /// <summary>
-        /// Calculates the precision from a confusion matrix
-        /// </summary>
-        /// <param name="cm">confusion matrix metrics</param>
-        /// <returns>The precision result</returns>
-        private static double Precision(this ConfusionMatrix cm)
-        {
-            return Divide(cm.TruePositive, cm.TruePositive + cm.FalsePositive);
-        }
-
-        /// <summary>
-        ///  Calculates the recall from a confusion matrix
-        /// </summary>
-        /// <param name="cm"> confusin matrix metrics</param>
-        /// <returns> The recall result</returns>
-        private static double Recall(this ConfusionMatrix cm)
-        {
-            return Divide(cm.TruePositive, cm.TruePositive + cm.FalseNegative);
-        }
-
-        /// <summary>
-        /// Calculates the f1 score from a confusion matrix
-        /// </summary>
-        /// <param name="cm"> confusion matrix metrics</param>
-        /// <returns> the f1 result</returns>
-        private static double F1(this ConfusionMatrix cm)
-        {
-            var precision = cm.Precision();
-            var recall = cm.Recall();
-            var denominator = precision + recall;
-            return Math.Abs(denominator) > double.Epsilon ? 2 * (precision * recall) / denominator : 0;
         }
 
         /// <summary>
@@ -128,14 +135,28 @@ namespace NLU.DevOps.ModelPerformance
                                            group => group.Count())
                                        .OrderByDescending(group => group.Value);
 
-            Console.WriteLine("== Intent Confusion Matrix == ");
+            Console.WriteLine("# Intent Confusion Matrix");
+
             var confusionMatrix = new ConsoleTable("Expected intent", "Actual Intent", "FP");
             falsePositiveIntents.ToList().ForEach(kvp =>
             {
                 confusionMatrix.AddRow(kvp.Key.Item1, kvp.Key.Item2, kvp.Value);
             });
 
-            confusionMatrix.Write();
+            confusionMatrix.Write(Format.MarkDown);
+        }
+
+        /// <summary>
+        /// Prints the current value and difference from the baseline.
+        /// </summary>
+        /// <param name="current">Current value.</param>
+        /// <param name="baseline">Baseline value.</param>
+        /// <returns>Printed value and difference with baseline.</returns>
+        private static string Print(double current, double? baseline)
+        {
+            return baseline.HasValue
+                ? string.Format(CultureInfo.CurrentCulture, "{0:0.0000} ({1:0.0000})", current, current - baseline)
+                : string.Format(CultureInfo.CurrentCulture, "{0:0.0000}", current);
         }
     }
 }

--- a/src/NLU.DevOps.ModelPerformance/NLUAccuracy.cs
+++ b/src/NLU.DevOps.ModelPerformance/NLUAccuracy.cs
@@ -39,17 +39,17 @@ namespace NLU.DevOps.ModelPerformance
                 .ToList()
                 .ForEach(intentItem =>
                 {
-                    var baselineResults = default(ConfusionMatrix);
-                    if (baseline != null && !baseline.ByIntent.TryGetValue(intentItem.Key, out baselineResults))
+                    var intentBaseline = default(ConfusionMatrix);
+                    if (baseline != null && !baseline.ByIntent.TryGetValue(intentItem.Key, out intentBaseline))
                     {
-                        baselineResults = ConfusionMatrix.Default;
+                        intentBaseline = ConfusionMatrix.Default;
                     }
 
-                    var intentPrecision = Print(intentItem.Value.Precision(), baselineResults?.Precision());
-                    var intentRecall = Print(intentItem.Value.Recall(), baselineResults?.Recall());
-                    var intentF1 = Print(intentItem.Value.F1(), baselineResults?.F1());
-                    var intentTotal = Print(intentItem.Value.Total(), baselineResults?.Total(), 0);
-                    var intentFP = Print(intentItem.Value.FalsePositive, baselineResults?.FalsePositive, 0);
+                    var intentPrecision = Print(intentItem.Value.Precision(), intentBaseline?.Precision());
+                    var intentRecall = Print(intentItem.Value.Recall(), intentBaseline?.Recall());
+                    var intentF1 = Print(intentItem.Value.F1(), intentBaseline?.F1());
+                    var intentTotal = Print(intentItem.Value.Total(), intentBaseline?.Total(), 0);
+                    var intentFP = Print(intentItem.Value.FalsePositive, intentBaseline?.FalsePositive, 0);
                     intentTable.AddRow(intentItem.Key, intentPrecision, intentRecall, intentF1, intentTotal, intentFP);
                 });
 
@@ -71,17 +71,17 @@ namespace NLU.DevOps.ModelPerformance
                 .ToList()
                 .ForEach(entityItem =>
                 {
-                    var baselineResults = default(ConfusionMatrix);
-                    if (baseline != null && !baseline.ByEntityType.TryGetValue(entityItem.Key, out baselineResults))
+                    var entityBaseline = default(ConfusionMatrix);
+                    if (baseline != null && !baseline.ByEntityType.TryGetValue(entityItem.Key, out entityBaseline))
                     {
-                        baselineResults = ConfusionMatrix.Default;
+                        entityBaseline = ConfusionMatrix.Default;
                     }
 
-                    var entityPrecision = Print(entityItem.Value.Precision(), baselineResults?.Precision());
-                    var entityRecall = Print(entityItem.Value.Recall(), baselineResults?.Recall());
-                    var entityF1 = Print(entityItem.Value.F1(), baselineResults?.F1());
-                    var entityTotal = Print(entityItem.Value.Total(), baselineResults?.Total(), 0);
-                    var entityFP = Print(entityItem.Value.FalsePositive, baselineResults?.FalsePositive, 0);
+                    var entityPrecision = Print(entityItem.Value.Precision(), entityBaseline?.Precision());
+                    var entityRecall = Print(entityItem.Value.Recall(), entityBaseline?.Recall());
+                    var entityF1 = Print(entityItem.Value.F1(), entityBaseline?.F1());
+                    var entityTotal = Print(entityItem.Value.Total(), entityBaseline?.Total(), 0);
+                    var entityFP = Print(entityItem.Value.FalsePositive, entityBaseline?.FalsePositive, 0);
                     entityTable.AddRow(entityItem.Key, entityPrecision, entityRecall, entityF1, entityTotal, entityFP);
                 });
 
@@ -187,9 +187,11 @@ namespace NLU.DevOps.ModelPerformance
         /// <returns>Printed value and difference with baseline.</returns>
         private static string Print(double current, double? baseline, int precision = 3)
         {
-            var format = $"0.{string.Join(string.Empty, Enumerable.Repeat("0", precision))}";
+            var precisionString = string.Join(string.Empty, Enumerable.Repeat("0", precision));
+            var format = $"0.{precisionString}";
+            var diffFormat = $"+0.{precisionString};-0.{precisionString};+0.{precisionString}";
             return baseline.HasValue
-                ? string.Format(CultureInfo.CurrentCulture, $"{{0:{format}}} ({{1:{format}}})", current, current - baseline)
+                ? string.Format(CultureInfo.CurrentCulture, $"{{0:{format}}} ({{1:{diffFormat}}})", current, current - baseline)
                 : string.Format(CultureInfo.CurrentCulture, $"{{0:{format}}}", current);
         }
     }


### PR DESCRIPTION
This PR implements the `--baseline` option for the `benchmark` command, which for now prints the performance difference between two test runs in a table.

Fixes #260