### PR TITLE
Adds thresholds to compare command configuration

### DIFF
--- a/models/compare.json
+++ b/models/compare.json
@@ -1,3 +1,0 @@
-{
-    "trueNegativeIntent": "None" 
-}

--- a/models/compare.yml
+++ b/models/compare.yml
@@ -1,0 +1,8 @@
+trueNegativeIntent: None
+thresholds:
+- type: intent
+  group: '*'
+  threshold: 0
+- type: entity
+  group: '*'
+  threshold: 0

--- a/pipelines/nlu-cli.yml
+++ b/pipelines/nlu-cli.yml
@@ -118,7 +118,7 @@ steps:
     arguments: compare
       --expected models/tests.json
       --actual $(Agent.TempDirectory)/results.json
-      --test-settings models/compare.json
+      --test-settings models/compare.yml
       --baseline $(Agent.TempDirectory)/drop/statistics.json
       --output-folder $(Build.ArtifactStagingDirectory)
 
@@ -131,7 +131,7 @@ steps:
     arguments: compare
       --expected models/tests.json
       --actual $(Agent.TempDirectory)/results.json
-      --test-settings models/compare.json
+      --test-settings models/compare.yml
       --output-folder $(Build.ArtifactStagingDirectory)      
 
 - task: DotNetCoreCLI@2
@@ -143,26 +143,15 @@ steps:
 
 - task: PublishTestResults@2
   displayName: Publish test results
+  condition: succeededOrFailed()
   inputs:
     testResultsFormat: NUnit
     testResultsFiles: $(Build.ArtifactStagingDirectory)/**/TestResult.xml
 
 - task: PublishBuildArtifacts@1
   displayName: Publish build artifacts
+  condition: succeededOrFailed()
   inputs:
     pathToPublish: $(Build.ArtifactStagingDirectory)
     artifactName: drop
     artifactType: container
-
-- task: UsePythonVersion@0
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['skipCompare'], true))
-  displayName: Set correct Python version
-  inputs:
-    versionSpec: '>= 3.5'   
-
-- task: PythonScript@0
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['skipCompare'], true))
-  displayName: Check for performance regression
-  inputs:
-    scriptPath: scripts/compare.py
-    arguments: $(Agent.TempDirectory)/drop/**/TestResult.xml $(Build.ArtifactStagingDirectory)/**/TestResult.xml

--- a/src/NLU.DevOps.ModelPerformance.Tests/TestSettingsTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestSettingsTests.cs
@@ -25,11 +25,19 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var settingsFile = Guid.NewGuid().ToString();
 
+            var threshold = new JObject
+            {
+                { "type", "intent" },
+                { "group", "*" },
+                { "threshold", 0.05 },
+            };
+
             var settings = new JObject
             {
                 { "trueNegativeIntent", "default" },
                 { "strictEntities", new JArray { "strict" } },
                 { "ignoreEntities", new JArray { "ignore" } },
+                { "thresholds", new JArray { threshold } },
             };
 
             File.WriteAllText(settingsFile, settings.ToString());
@@ -40,6 +48,10 @@ namespace NLU.DevOps.ModelPerformance.Tests
                 testSettings.TrueNegativeIntent.Should().Be("default");
                 testSettings.StrictEntities.Should().BeEquivalentTo("strict");
                 testSettings.IgnoreEntities.Should().BeEquivalentTo("ignore");
+                testSettings.Thresholds.Count.Should().Be(1);
+                testSettings.Thresholds[0].Type.Should().Be("intent");
+                testSettings.Thresholds[0].Group.Should().Be("*");
+                testSettings.Thresholds[0].Threshold.Should().BeApproximately(0.05, 0.001);
             }
             finally
             {
@@ -50,7 +62,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
         [Test]
         public static void CreateFromYaml()
         {
-            var settingsFile = $"{Guid.NewGuid().ToString()}.yml";
+            var settingsFile = $"{Guid.NewGuid()}.yml";
             var settings = new[]
             {
                 "trueNegativeIntent: default",
@@ -58,6 +70,10 @@ namespace NLU.DevOps.ModelPerformance.Tests
                 "- strict",
                 "ignoreEntities:",
                 "- ignore",
+                "thresholds:",
+                "- type: intent",
+                "  group: '*'",
+                "  threshold: 0.05",
             };
 
             File.WriteAllText(settingsFile, string.Join(Environment.NewLine, settings));
@@ -68,6 +84,10 @@ namespace NLU.DevOps.ModelPerformance.Tests
                 testSettings.TrueNegativeIntent.Should().Be("default");
                 testSettings.StrictEntities.Should().BeEquivalentTo("strict");
                 testSettings.IgnoreEntities.Should().BeEquivalentTo("ignore");
+                testSettings.Thresholds.Count.Should().Be(1);
+                testSettings.Thresholds[0].Type.Should().Be("intent");
+                testSettings.Thresholds[0].Group.Should().Be("*");
+                testSettings.Thresholds[0].Threshold.Should().BeApproximately(0.05, 0.001);
             }
             finally
             {

--- a/src/NLU.DevOps.ModelPerformance.Tests/TestSettingsTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestSettingsTests.cs
@@ -36,11 +36,35 @@ namespace NLU.DevOps.ModelPerformance.Tests
 
             try
             {
-                var configuration = new ConfigurationBuilder()
-                    .AddJsonFile(settingsFile)
-                    .Build();
+                var testSettings = new TestSettings(settingsFile, false);
+                testSettings.TrueNegativeIntent.Should().Be("default");
+                testSettings.StrictEntities.Should().BeEquivalentTo("strict");
+                testSettings.IgnoreEntities.Should().BeEquivalentTo("ignore");
+            }
+            finally
+            {
+                File.Delete(settingsFile);
+            }
+        }
 
-                var testSettings = new TestSettings(configuration, false);
+        [Test]
+        public static void CreateFromYaml()
+        {
+            var settingsFile = $"{Guid.NewGuid().ToString()}.yml";
+            var settings = new[]
+            {
+                "trueNegativeIntent: default",
+                "strictEntities:",
+                "- strict",
+                "ignoreEntities:",
+                "- ignore",
+            };
+
+            File.WriteAllText(settingsFile, string.Join(Environment.NewLine, settings));
+
+            try
+            {
+                var testSettings = new TestSettings(settingsFile, false);
                 testSettings.TrueNegativeIntent.Should().Be("default");
                 testSettings.StrictEntities.Should().BeEquivalentTo("strict");
                 testSettings.IgnoreEntities.Should().BeEquivalentTo("ignore");

--- a/src/NLU.DevOps.ModelPerformance/NLU.DevOps.ModelPerformance.csproj
+++ b/src/NLU.DevOps.ModelPerformance/NLU.DevOps.ModelPerformance.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+    <PackageReference Include="NetEscapades.Configuration.Yaml" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NLU.DevOps.ModelPerformance/NLUThreshold.cs
+++ b/src/NLU.DevOps.ModelPerformance/NLUThreshold.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.ModelPerformance
+{
+    /// <summary>
+    /// Measurement threshold for NLU comparison.
+    /// </summary>
+    public class NLUThreshold
+    {
+        /// <summary>
+        /// Gets or sets the type of measurement to compare, one of "intent" or "entity".
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the key to compare, one of intent name, entity type, or "*".
+        /// </summary>
+        public string Group { get; set; }
+
+        /// <summary>
+        /// Gets or sets the threshold.
+        /// </summary>
+        public double Threshold { get; set; }
+    }
+}

--- a/src/NLU.DevOps.ModelPerformance/TestCaseSource.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestCaseSource.cs
@@ -439,22 +439,14 @@ namespace NLU.DevOps.ModelPerformance
                 throw new InvalidOperationException("Could not find configuration for expected or actual utterances.");
             }
 
-            IConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
-
             var testSettingsPath = TestContext.Parameters.Get(ConfigurationConstants.TestSettingsPathKey);
-            if (testSettingsPath != null)
-            {
-                configurationBuilder = configurationBuilder
-                    .AddJsonFile(Path.Combine(Directory.GetCurrentDirectory(), testSettingsPath));
-            }
-
             var unitTestModeString = TestContext.Parameters.Get(ConfigurationConstants.UnitTestModeKey);
             if (unitTestModeString == null || !bool.TryParse(unitTestModeString, out var unitTestMode))
             {
                 unitTestMode = false;
             }
 
-            var testSettings = new TestSettings(configurationBuilder.Build(), unitTestMode);
+            var testSettings = new TestSettings(testSettingsPath, unitTestMode);
             var expected = Read(expectedPath);
             var actual = Read(actualPath);
             return GetNLUCompareResults(expected, actual, testSettings).TestCases;

--- a/src/NLU.DevOps.ModelPerformance/TestSettings.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestSettings.cs
@@ -66,7 +66,12 @@ namespace NLU.DevOps.ModelPerformance
         {
             IConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
 
-            if (path != null)
+            if (path != null && (path.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) || path.EndsWith(".yml", StringComparison.OrdinalIgnoreCase)))
+            {
+                configurationBuilder = configurationBuilder
+                    .AddYamlFile(Path.Combine(Directory.GetCurrentDirectory(), path));
+            }
+            else if (path != null)
             {
                 configurationBuilder = configurationBuilder
                     .AddJsonFile(Path.Combine(Directory.GetCurrentDirectory(), path));

--- a/src/NLU.DevOps.ModelPerformance/TestSettings.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestSettings.cs
@@ -6,6 +6,7 @@ namespace NLU.DevOps.ModelPerformance
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using Microsoft.Extensions.Configuration;
 
     /// <summary>
@@ -16,6 +17,7 @@ namespace NLU.DevOps.ModelPerformance
         private const string IgnoreEntitiesConfigurationKey = "ignoreEntities";
         private const string StrictEntitiesConfigurationKey = "strictEntities";
         private const string TrueNegativeIntentConfigurationKey = "trueNegativeIntent";
+        private const string ThresholdsConfigurationKey = "thresholds";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestSettings"/> class.
@@ -56,6 +58,11 @@ namespace NLU.DevOps.ModelPerformance
         public IReadOnlyList<string> StrictEntities => this.Configuration.GetSection(StrictEntitiesConfigurationKey).Get<string[]>() ?? Array.Empty<string>();
 
         /// <summary>
+        /// Gets the set of thresholds defined in the configuration.
+        /// </summary>
+        public IReadOnlyList<NLUThreshold> Thresholds => this.GetThresholds() ?? Array.Empty<NLUThreshold>();
+
+        /// <summary>
         /// Gets the name of the intent used for true negatives.
         /// </summary>
         public string TrueNegativeIntent => this.Configuration.GetValue(TrueNegativeIntentConfigurationKey, default(string));
@@ -78,6 +85,20 @@ namespace NLU.DevOps.ModelPerformance
             }
 
             return configurationBuilder.Build();
+        }
+
+        private IReadOnlyList<NLUThreshold> GetThresholds()
+        {
+            return this.Configuration
+                .GetSection(ThresholdsConfigurationKey)?
+                .GetChildren()?
+                .Select(item =>
+                {
+                    var threshold = new NLUThreshold();
+                    item.Bind(threshold);
+                    return threshold;
+                })
+                .ToArray();
         }
     }
 }


### PR DESCRIPTION
Adds option to specify regression thresholds for F1 score performance
for intents and entities. If the performance drops more than the given
threshold for an NLU intent or entity type, the compare command will
return a non-zero exit code (failing the build in most CI environments).

Fixes #278