### PR TITLE
Adds baseline compare behavior to AzDO extension

### DIFF
--- a/extensions/tasks/NLUCleanV0/task.json
+++ b/extensions/tasks/NLUCleanV0/task.json
@@ -31,18 +31,18 @@
             "helpMarkDown": "Usually one of: 'luis', 'luisV3', or 'lex'."
         },
         {
-            "name": "includePath",
-            "type": "string",
-            "label": "NLU.DevOps custom NLU provider include path.",
-            "required": false,
-            "helpMarkDown": "[Learn more about this option](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Clean.md#include)."
-        },
-        {
             "name": "workingDirectory",
             "type": "filePath",
             "label": "Working Directory",
             "helpMarkDown": "Current working directory where the script is run. Empty is the root of the repo (build) or artifacts (release), which is $(System.DefaultWorkingDirectory)",
             "required": false
+        },
+        {
+            "name": "includePath",
+            "type": "string",
+            "label": "NLU.DevOps custom NLU provider include path.",
+            "required": false,
+            "helpMarkDown": "[Learn more about this option](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Clean.md#-i---include)."
         },
         {
             "name": "nupkgPath",

--- a/extensions/tasks/NLUTestV0/__tests__/runTask.spec.ts
+++ b/extensions/tasks/NLUTestV0/__tests__/runTask.spec.ts
@@ -27,8 +27,7 @@ describe("NLUTest", () => {
     let addAttachmentStub: sinon.SinonStub<any[], any>;
     let addBuildTagStub: sinon.SinonStub<any[], any>;
     let getBuildStatisticsStub: sinon.SinonStub<any[], any>;
-    let downloadStatisticsFromBranchStub: sinon.SinonStub<any[], any>;
-    let downloadStatisticsFromBuildIdStub: sinon.SinonStub<any[], any>;
+    let downloadBuildStatisticsStub: sinon.SinonStub<any[], any>;
     let writeFileSyncStub: sinon.SinonStub<any[], any>;
     let getVariableStub: sinon.SinonStub<any[], any>;
 
@@ -43,8 +42,7 @@ describe("NLUTest", () => {
         addAttachmentStub = ImportMock.mockFunction(tl, "addAttachment");
         addBuildTagStub = ImportMock.mockFunction(tl, "addBuildTag");
         getBuildStatisticsStub = ImportMock.mockFunction(artifacts, "getBuildStatistics");
-        downloadStatisticsFromBranchStub = ImportMock.mockFunction(artifacts, "downloadStatisticsFromBranch");
-        downloadStatisticsFromBuildIdStub = ImportMock.mockFunction(artifacts, "downloadStatisticsFromBuildId");
+        downloadBuildStatisticsStub = ImportMock.mockFunction(artifacts, "downloadBuildStatistics");
         writeFileSyncStub = ImportMock.mockFunction(fs, "writeFileSync");
 
         getVariableStub = ImportMock.mockFunction(tl, "getVariable");
@@ -63,8 +61,7 @@ describe("NLUTest", () => {
         addBuildTagStub.restore();
         writeFileSyncStub.restore();
         getBuildStatisticsStub.restore();
-        downloadStatisticsFromBranchStub.restore();
-        downloadStatisticsFromBuildIdStub.restore();
+        downloadBuildStatisticsStub.restore();
 
         getVariableStub.restore();
     });
@@ -95,8 +92,7 @@ describe("NLUTest", () => {
         addAttachmentStub.reset();
         addBuildTagStub.reset();
         getBuildStatisticsStub.reset();
-        downloadStatisticsFromBranchStub.reset();
-        downloadStatisticsFromBuildIdStub.reset();
+        downloadBuildStatisticsStub.reset();
         writeFileSyncStub.reset();
 
         // restore tl.tool method
@@ -203,7 +199,7 @@ describe("NLUTest", () => {
         getBoolInputStub.withArgs("publishTestResults").returns(true);
 
         // stub previous build results
-        downloadStatisticsFromBranchStub.returns([]);
+        downloadBuildStatisticsStub.returns([]);
 
         // stub test results match
         const resultFiles = [ "foo" ];
@@ -253,7 +249,7 @@ describe("NLUTest", () => {
         getBoolInputStub.withArgs("publishTestResults").returns(true);
 
         // stub previous build results
-        downloadStatisticsFromBranchStub.returns([]);
+        downloadBuildStatisticsStub.returns([]);
 
         // stub test results match
         const resultsFiles = [];
@@ -284,7 +280,7 @@ describe("NLUTest", () => {
 
         // stub previous build results
         getBuildStatisticsStub.returns([]);
-        downloadStatisticsFromBranchStub.returns([]);
+        downloadBuildStatisticsStub.returns([]);
 
         // run test
         await run();
@@ -318,7 +314,7 @@ describe("NLUTest", () => {
 
         // stub previous build results
         getBuildStatisticsStub.returns([]);
-        downloadStatisticsFromBranchStub.returns([]);
+        downloadBuildStatisticsStub.returns([]);
 
         // run test
         await run();
@@ -353,7 +349,7 @@ describe("NLUTest", () => {
         getInputStub.withArgs("compareOutput").returns(compareOutput);
 
         // stub previous build results
-        downloadStatisticsFromBranchStub.returns([]);
+        downloadBuildStatisticsStub.returns([]);
 
         // run test
         await run();
@@ -382,7 +378,7 @@ describe("NLUTest", () => {
         getInputStub.withArgs("compareOutput").returns(compareOutput);
 
         // stub previous build results
-        downloadStatisticsFromBranchStub.returns([]);
+        downloadBuildStatisticsStub.returns([]);
 
         // run test
         await run();
@@ -391,67 +387,7 @@ describe("NLUTest", () => {
         expect(setResultStub.calledWith(tl.TaskResult.Failed)).to.be.ok;
     });
 
-    it("adds baseline when baselineBuildType is specific", async () => {
-        // stub exec
-        const execStub = toolMock.mock("exec");
-        execStub.onCall(0).returns(0);
-        execStub.onCall(1).returns(0);
-
-        // stub inputs
-        const service = "foo";
-        const utterances = "bar";
-        const compareOutput = "compareOutput";
-        getInputStub.withArgs("service").returns(service);
-        getInputStub.withArgs("utterances").returns(utterances);
-        getInputStub.withArgs("baselineBuildType").returns("specific");
-        getInputStub.withArgs("baselineBuildId").returns("42");
-        getInputStub.withArgs("compareOutput").returns(compareOutput);
-
-        // stub previous build results
-        downloadStatisticsFromBuildIdStub.returns("baseline");
-
-        // run test
-        await run();
-
-        // assert calls
-        const calls = argMock.getCalls();
-        expect(downloadStatisticsFromBuildIdStub.firstCall.calledWith(42)).to.be.ok;
-        expect(calls.length).to.equal(8 /* test */ + 9 /* compare */);
-        expect(calls[15].calledWith("-b")).to.be.ok;
-        expect(calls[16].calledWith("baseline")).to.be.ok;
-    });
-
-    it("adds baseline when baselineBuildType is latestFromBranch", async () => {
-        // stub exec
-        const execStub = toolMock.mock("exec");
-        execStub.onCall(0).returns(0);
-        execStub.onCall(1).returns(0);
-
-        // stub inputs
-        const service = "foo";
-        const utterances = "bar";
-        const compareOutput = "compareOutput";
-        getInputStub.withArgs("service").returns(service);
-        getInputStub.withArgs("utterances").returns(utterances);
-        getInputStub.withArgs("baselineBuildType").returns("latestFromBranch");
-        getInputStub.withArgs("baselineBranchName").returns("branchName");
-        getInputStub.withArgs("compareOutput").returns(compareOutput);
-
-        // stub previous build results
-        downloadStatisticsFromBranchStub.returns([ { path: "baseline" } ]);
-
-        // run test
-        await run();
-
-        // assert calls
-        const calls = argMock.getCalls();
-        expect(downloadStatisticsFromBranchStub.firstCall.calledWith(1, "branchName")).to.be.ok;
-        expect(calls.length).to.equal(8 /* test */ + 9 /* compare */);
-        expect(calls[15].calledWith("-b")).to.be.ok;
-        expect(calls[16].calledWith("baseline")).to.be.ok;
-    });
-
-    it("adds baseline when baselineBuildType is latest", async () => {
+    it("adds baseline when returned by downloadBuildStatistics", async () => {
         // stub exec
         const execStub = toolMock.mock("exec");
         execStub.onCall(0).returns(0);
@@ -466,14 +402,13 @@ describe("NLUTest", () => {
         getInputStub.withArgs("compareOutput").returns(compareOutput);
 
         // stub previous build results
-        downloadStatisticsFromBranchStub.returns([ { path: "baseline" } ]);
+        downloadBuildStatisticsStub.returns([ { path: "baseline" } ]);
 
         // run test
         await run();
 
         // assert calls
         const calls = argMock.getCalls();
-        expect(downloadStatisticsFromBranchStub.firstCall.calledWith(1)).to.be.ok;
         expect(calls.length).to.equal(8 /* test */ + 9 /* compare */);
         expect(calls[15].calledWith("-b")).to.be.ok;
         expect(calls[16].calledWith("baseline")).to.be.ok;
@@ -494,8 +429,14 @@ describe("NLUTest", () => {
         getInputStub.withArgs("baselineBuildType").returns("latestFromBranch");
         getInputStub.withArgs("compareOutput").returns(compareOutput);
 
+        // disable downloadBuildStatistics stub
+        downloadBuildStatisticsStub.restore();
+
         // run test
         await run();
+
+        // re-enable the downloadBuildStatistics stub
+        downloadBuildStatisticsStub = ImportMock.mockFunction(artifacts, "downloadBuildStatistics");
 
         // assert result
         expect(setResultStub.calledWith(tl.TaskResult.Failed)).to.be.ok;
@@ -517,8 +458,14 @@ describe("NLUTest", () => {
         getInputStub.withArgs("baselineBuildType").returns("specific");
         getInputStub.withArgs("compareOutput").returns(compareOutput);
 
+        // disable downloadBuildStatistics stub
+        downloadBuildStatisticsStub.restore();
+
         // run test
         await run();
+
+        // re-enable the downloadBuildStatistics stub
+        downloadBuildStatisticsStub = ImportMock.mockFunction(artifacts, "downloadBuildStatistics");
 
         // assert result
         expect(setResultStub.calledWith(tl.TaskResult.Failed)).to.be.ok;

--- a/extensions/tasks/NLUTestV0/artifacts.ts
+++ b/extensions/tasks/NLUTestV0/artifacts.ts
@@ -48,7 +48,7 @@ export async function downloadBuildStatistics(count: number) {
             {
                 id: buildIdInput,
                 path: await downloadStatisticsFromBuildId(buildId),
-            }
+            },
         ];
     }
 

--- a/extensions/tasks/NLUTestV0/runTask.ts
+++ b/extensions/tasks/NLUTestV0/runTask.ts
@@ -191,7 +191,8 @@ async function downloadBaselineStatistics() {
             throw new Error("Must specify a branch name in 'baselineBranchName'.");
         }
 
-        return await downloadStatisticsFromBranch(1, branchName);
+        const results = await downloadStatisticsFromBranch(1, branchName);
+        return results.length && results[0].path;
     }
 
     const results = await downloadStatisticsFromBranch(1);

--- a/extensions/tasks/NLUTestV0/runTask.ts
+++ b/extensions/tasks/NLUTestV0/runTask.ts
@@ -6,7 +6,11 @@ import * as tr from "azure-pipelines-task-lib/toolrunner";
 import { writeFileSync } from "fs";
 import { getNLUToolRunner } from "nlu-devops-common/utilities";
 import * as path from "path";
-import { getBuildStatistics } from "./artifacts";
+import {
+    downloadStatisticsFromBranch,
+    downloadStatisticsFromBuildId,
+    getBuildStatistics,
+} from "./artifacts";
 
 export async function run() {
     try {
@@ -84,9 +88,16 @@ async function runNLUCompare(output): Promise<any> {
         .arg("-o")
         .arg(compareOutput);
 
-    const publishNLUResultsInput = tl.getBoolInput("publishNLUResults");
-    if (publishNLUResultsInput) {
-        tool.arg("-m");
+    const testSettings = tl.getInput("testSettings");
+    if (testSettings) {
+        tool.arg("-t")
+            .arg(testSettings);
+    }
+
+    const baseline = await downloadBaselineStatistics();
+    if (baseline) {
+        tool.arg("-b")
+            .arg(baseline);
     }
 
     let isError = false;
@@ -145,27 +156,46 @@ async function publishNLUResults() {
 
     const compareOutput = getCompareOutputPath() as string;
 
-    console.log("Publishing metadata attachment for NLU results.");
     tl.addAttachment("nlu.devops", "metadata.json", path.join(compareOutput, `metadata.json`));
 
-    console.log("Publishing statistics attachment for NLU results.");
     const statisticsPath = path.join(compareOutput, "statistics.json");
     const allStatisticsPath = path.join(compareOutput, "allStatistics.json");
     const buildStatistics = await getBuildStatistics(statisticsPath);
     writeFileSync(allStatisticsPath, JSON.stringify(buildStatistics, null, 2));
     tl.addAttachment("nlu.devops", "statistics.json", allStatisticsPath);
 
-    if (tl.getVariable("Build.SourceBranch") === "refs/heads/master") {
-        const publishData = {
-            artifactname: "statistics",
-            artifacttype: "container",
-            containerfolder: "statistics",
-            localpath: statisticsPath,
-        };
+    const publishData = {
+        artifactname: "statistics",
+        artifacttype: "container",
+        containerfolder: "statistics",
+        localpath: statisticsPath,
+    };
 
-        tl.command("artifact.upload", publishData, statisticsPath);
-        tl.addBuildTag("nlu.devops.statistics");
+    tl.command("artifact.upload", publishData, statisticsPath);
+    tl.addBuildTag("nlu.devops.statistics");
+}
+
+async function downloadBaselineStatistics() {
+    const buildType = tl.getInput("baselineBuildType");
+    if (buildType === "specific") {
+        const buildIdInput = tl.getInput("baselineBuildId");
+        const buildId = parseInt(buildIdInput, 10);
+        if (Number.isNaN(buildId)) {
+            throw new Error("Must specify a valid build ID in 'baselineBuildId' input.");
+        }
+
+        return await downloadStatisticsFromBuildId(buildId);
+    } else if (buildType === "latestFromBranch") {
+        const branchName = tl.getInput("baselineBranchName");
+        if (!branchName) {
+            throw new Error("Must specify a branch name in 'baselineBranchName'.");
+        }
+
+        return await downloadStatisticsFromBranch(1, branchName);
     }
+
+    const results = await downloadStatisticsFromBranch(1);
+    return results.length && results[0].path;
 }
 
 function getOutputPath() {

--- a/extensions/tasks/NLUTestV0/runTask.ts
+++ b/extensions/tasks/NLUTestV0/runTask.ts
@@ -185,17 +185,14 @@ async function downloadBaselineStatistics() {
         }
 
         return await downloadStatisticsFromBuildId(buildId);
-    } else if (buildType === "latestFromBranch") {
-        const branchName = tl.getInput("baselineBranchName");
-        if (!branchName) {
-            throw new Error("Must specify a branch name in 'baselineBranchName'.");
-        }
-
-        const results = await downloadStatisticsFromBranch(1, branchName);
-        return results.length && results[0].path;
     }
 
-    const results = await downloadStatisticsFromBranch(1);
+    const branchName = tl.getInput("baselineBranchName") || undefined;
+    if (buildType === "latestFromBranch" && !branchName) {
+        throw new Error("Must specify a branch name in 'baselineBranchName'.");
+    }
+
+    const results = await downloadStatisticsFromBranch(1, branchName);
     return results.length && results[0].path;
 }
 

--- a/extensions/tasks/NLUTestV0/task.json
+++ b/extensions/tasks/NLUTestV0/task.json
@@ -62,19 +62,20 @@
             "helpMarkDown": "[Learn more about this option](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Test.md#-d---speech-directory)."
         },
         {
-            "name": "includePath",
-            "type": "string",
-            "label": "NLU.DevOps custom NLU provider include path.",
-            "required": false,
-            "helpMarkDown": "[Learn more about this option](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Test.md#include)."
-        },
-        {
             "name": "compareOutput",
             "type": "string",
             "label": "Base directory where compare output will be stored.",
             "required": false,
             "defaultValue": null,
-            "helpMarkDown": "[Learn more about this option]()."
+            "helpMarkDown": "[Learn more about this option](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Analyze.md#-o---output-folder)."
+        },
+        {
+            "name": "testSettings",
+            "type": "string",
+            "label": "Test settings for configuring NLU confusion matrix analysis.",
+            "required": false,
+            "defaultValue": null,
+            "helpMarkDown": "[Learn more about this option](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Analyze.md#-t---test-settings)."
         },
         {
             "name": "publishTestResults",
@@ -82,7 +83,7 @@
             "label": "Signals whether to publish a test results tab.",
             "required": false,
             "defaultValue": false,
-            "helpMarkDown": "Uses generated NUnit output from NLU.DevOps `compare` command to populate the test results tab. [Learn more about the `compare` command](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Compare.md)."
+            "helpMarkDown": "Uses generated NUnit output from NLU.DevOps `compare` command to populate the test results tab. [Learn more about the `compare` command](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Analyze.md)."
         },
         {
             "name": "publishNLUResults",
@@ -90,7 +91,31 @@
             "label": "Signals whether to publish an NLU results tab.",
             "required": false,
             "defaultValue": false,
-            "helpMarkDown": "Uses generated JSON metadata output from NLU.DevOps `compare` command to populate the NLU results tab. [Learn more about the `compare` command](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Compare.md)."
+            "helpMarkDown": "Uses generated JSON metadata output from NLU.DevOps `benchmark` command to populate the NLU results tab. [Learn more about the `benchmark` command](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Analyze.md)."
+        },
+        {
+            "name": "baselineBuildType",
+            "type": "string",
+            "label": "Specifies how to download the baseline build artifact. Options: latest, latestFromBranch, specific",
+            "helpMarkDown": "Specifies how to download the baseline build artifact. Options: latest, latestFromBranch, specific",
+            "required": false,
+            "defaultValue": null
+        },
+        {
+            "name": "baselineBranchName",
+            "type": "string",
+            "label": "Specifies which branch to download the baseline build artifact. Required when baselineBuildType == latestFromBranch",
+            "helpMarkDown": "Specifies which branch to download the baseline build artifact. Required when baselineBuildType == latestFromBranch",
+            "required": false,
+            "defaultValue": null
+        },
+        {
+            "name": "baselineBuildId",
+            "type": "string",
+            "label": "Specifies the specific build to download the baseline build artifact. Required when baselineBuildType == specific",
+            "helpMarkDown": "Specifies the specific build to download the baseline build artifact. Required when baselineBuildType == specific",
+            "required": false,
+            "defaultValue": null
         },
         {
             "name": "compareBuildCount",
@@ -99,6 +124,13 @@
             "helpMarkDown": "Number of previous builds to compare against in NLU results.",
             "required": false,
             "defaultValue": "1"
+        },
+        {
+            "name": "includePath",
+            "type": "string",
+            "label": "NLU.DevOps custom NLU provider include path.",
+            "required": false,
+            "helpMarkDown": "[Learn more about this option](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Test.md#-i---include)."
         },
         {
             "name": "workingDirectory",

--- a/extensions/tasks/NLUTrainV0/task.json
+++ b/extensions/tasks/NLUTrainV0/task.json
@@ -45,18 +45,18 @@
             "helpMarkDown": "[Learn more about this option](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Train.md#-m---model-settings)."
         },
         {
-            "name": "includePath",
-            "type": "string",
-            "label": "NLU.DevOps custom NLU provider include path.",
-            "required": false,
-            "helpMarkDown": "[Learn more about this option](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Train.md#include)."
-        },
-        {
             "name": "workingDirectory",
             "type": "filePath",
             "label": "Working Directory",
             "helpMarkDown": "Current working directory where the script is run. Empty is the root of the repo (build) or artifacts (release), which is $(System.DefaultWorkingDirectory)",
             "required": false
+        },
+        {
+            "name": "includePath",
+            "type": "string",
+            "label": "NLU.DevOps custom NLU provider include path.",
+            "required": false,
+            "helpMarkDown": "[Learn more about this option](https://github.com/microsoft/NLU.DevOps/blob/master/docs/Train.md#-i---include)."
         },
         {
             "name": "nupkgPath",


### PR DESCRIPTION
Adds new inputs to the `NLUTest` AzDO task:
- `testSettings`: the test settings path added to NLU.DevOps.ModelPerformance
- `baselineBuildType`: similar to the first-party DownloadBuildArtifacts task, one of "latest", "latestFromBranch" or "specific"
- `baselineBranchName`: branch name to download statistics from, required for baselineBuildType == "latestFromBranch"
- `baselineBuildId`: build ID to download statistics from, required for baselineBuildType == "specific"

Also updates the task to target remove the no longer relevant `-m` flag.

Fixes #277