### PR TITLE
Fixes minor issues with compare command

### DIFF
--- a/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareCommand.cs
@@ -31,14 +31,14 @@ namespace NLU.DevOps.CommandLine.Compare
             var actualUtterances = Read<List<JsonLabeledUtterance>>(options.ActualUtterancesPath);
             var testSettings = new TestSettings(options.TestSettingsPath, options.UnitTestMode);
             var compareResults = TestCaseSource.GetNLUCompareResults(expectedUtterances, actualUtterances, testSettings);
-            var metadataPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestMetadataFileName) : TestMetadataFileName;
-            var statisticsPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestStatisticsFileName) : TestStatisticsFileName;
-
-            Write(metadataPath, compareResults.TestCases);
-            File.WriteAllText(statisticsPath, JObject.FromObject(compareResults.Statistics).ToString());
 
             var baseline = options.BaselinePath != null ? Read<NLUStatistics>(options.BaselinePath) : null;
             compareResults.PrintResults(baseline);
+
+            var metadataPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestMetadataFileName) : TestMetadataFileName;
+            var statisticsPath = options.OutputFolder != null ? Path.Combine(options.OutputFolder, TestStatisticsFileName) : TestStatisticsFileName;
+            Write(metadataPath, compareResults.TestCases);
+            File.WriteAllText(statisticsPath, JObject.FromObject(compareResults.Statistics).ToString());
 
             return 0;
         }

--- a/src/NLU.DevOps.CommandLine/Compare/CompareOptions.cs
+++ b/src/NLU.DevOps.CommandLine/Compare/CompareOptions.cs
@@ -23,7 +23,7 @@ namespace NLU.DevOps.CommandLine.Compare
         [Option('u', "unit-test", HelpText = "Runs compare operation in unit test mode.", Required = false)]
         public bool UnitTestMode { get; set; }
 
-        [Option('b', "baseline", HelpText = "Path to baseline confusion matrix results. Optional when '--mode' is set to 'performance' and '--format' is set to 'json'.", Required = false)]
+        [Option('b', "baseline", HelpText = "Path to baseline confusion matrix results.", Required = false)]
         public string BaselinePath { get; set; }
 
         [Option('m', "metadata", HelpText = "No longer relevant flag which will be removed in future build.", Required = false, Hidden = true)]


### PR DESCRIPTION
1. Removes outdated help message information for the `--baseline` option in the `compare` command.
2. Prints baseline / F-measure information before writing results.