### PR TITLE
Adds baseline compare example to AzDO pipeline

### DIFF
--- a/pipelines/nlu-cli.yml
+++ b/pipelines/nlu-cli.yml
@@ -96,6 +96,19 @@ steps:
       --service $(nlu.service)
       --delete-appsettings
 
+- task: DownloadBuildArtifacts@0
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+  displayName: Download test results from master
+  inputs:
+    buildType: specific
+    project: $(System.TeamProject)
+    pipeline: $(Build.DefinitionName)
+    buildVersionToDownload: latestFromBranch
+    branchName: refs/heads/master
+    downloadType: single
+    artifactName: drop
+    downloadPath: $(Agent.TempDirectory)
+
 - task: DotNetCoreCLI@2
   displayName: Compare the NLU text results
   inputs:
@@ -105,6 +118,7 @@ steps:
       --expected models/tests.json
       --actual $(Agent.TempDirectory)/results.json
       --test-settings models/compare.json
+      --baseline $(Agent.TempDirectory)/drop/statistics.json
       --output-folder $(Build.ArtifactStagingDirectory)
 
 - task: DotNetCoreCLI@2
@@ -127,19 +141,6 @@ steps:
     pathToPublish: $(Build.ArtifactStagingDirectory)
     artifactName: drop
     artifactType: container
-
-- task: DownloadBuildArtifacts@0
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-  displayName: Download test results from master
-  inputs:
-    buildType: specific
-    project: $(System.TeamProject)
-    pipeline: $(Build.DefinitionName)
-    buildVersionToDownload: latestFromBranch
-    branchName: refs/heads/master
-    downloadType: single
-    artifactName: drop
-    downloadPath: $(Agent.TempDirectory)
 
 - task: UsePythonVersion@0
   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))


### PR DESCRIPTION
Adds an example to leverage the statistics of a previous build to see
the diff in F1 score, precision, and recall for all intents and entities
in the model.