### PR TITLE
Fixes build break for CI

### DIFF
--- a/pipelines/nlu-cli.yml
+++ b/pipelines/nlu-cli.yml
@@ -97,7 +97,6 @@ steps:
       --delete-appsettings
 
 - task: DownloadBuildArtifacts@0
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
   displayName: Download test results from master
   inputs:
     buildType: specific


### PR DESCRIPTION
Ensures that previous build results are always downloaded for compare command.