### PR TITLE
Disables logging from test command

### DIFF
--- a/src/NLU.DevOps.Luis/LuisTestClient.cs
+++ b/src/NLU.DevOps.Luis/LuisTestClient.cs
@@ -55,6 +55,7 @@ namespace NLU.DevOps.Luis
                             this.LuisConfiguration.AppId,
                             text,
                             staging: this.LuisConfiguration.IsStaging,
+                            log: false,
                             cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }

--- a/src/NLU.DevOps.LuisV3/LuisTestClient.cs
+++ b/src/NLU.DevOps.LuisV3/LuisTestClient.cs
@@ -56,6 +56,7 @@ namespace NLU.DevOps.Luis
                                 this.LuisConfiguration.VersionId,
                                 predictionRequest,
                                 verbose: true,
+                                log: false,
                                 cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
                     }
@@ -65,6 +66,7 @@ namespace NLU.DevOps.Luis
                             this.LuisConfiguration.SlotName,
                             predictionRequest,
                             verbose: true,
+                            log: false,
                             cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }


### PR DESCRIPTION
When running batch predictions, this change sets the log parameter to false for LUIS so the tests are not reported in the query logs for the endpoint.

Fixes #288