### PR TITLE
Disables more false positives in unit test mode

### DIFF
--- a/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
@@ -709,6 +709,24 @@ namespace NLU.DevOps.ModelPerformance.Tests
         }
 
         [Test]
+        public static void NoFalsePositiveIntentsUnitTestMode()
+        {
+            var expectedUtterance = new LabeledUtterance(null, null, null);
+            var actualUtterance = new LabeledUtterance(null, "foo", null);
+            var testSettings = new TestSettings(default(string), true);
+
+            var compareResults = TestCaseSource.GetNLUCompareResults(
+                new[] { expectedUtterance },
+                new[] { actualUtterance },
+                testSettings);
+
+            compareResults.Statistics.Intent.TruePositive.Should().Be(0);
+            compareResults.Statistics.Intent.TrueNegative.Should().Be(0);
+            compareResults.Statistics.Intent.FalsePositive.Should().Be(0);
+            compareResults.Statistics.Intent.FalseNegative.Should().Be(0);
+        }
+
+        [Test]
         [TestCase("foo", "foo", 0, 1, 0, 0)]
         [TestCase(null, null, 0, 1, 0, 0)]
         [TestCase(null, "None", 0, 0, 1, 0)]

--- a/src/NLU.DevOps.ModelPerformance/TestCaseSource.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestCaseSource.cs
@@ -145,7 +145,7 @@ namespace NLU.DevOps.ModelPerformance
                     "Utterances have matching text.",
                     "Text");
             }
-            else
+            else if (!testInput.TestSettings.UnitTestMode)
             {
                 yield return FalsePositive(
                     testInput.UtteranceId,
@@ -221,7 +221,7 @@ namespace NLU.DevOps.ModelPerformance
                     "Intent");
             }
 
-            if (!isNoneIntent(actual))
+            if (!isNoneIntent(actual) && !testInput.TestSettings.UnitTestMode)
             {
                 yield return FalsePositive(
                     testInput.UtteranceId,


### PR DESCRIPTION
Disables text and intent false positives in unit test mode so users
can write tests that, e.g., only test entities.

Fixes #290