### PR TITLE
Allows test overrides of Dialogflow retry delay

### DIFF
--- a/src/NLU.DevOps.Dialogflow.Tests/DialogflowNLUTestClientTests.cs
+++ b/src/NLU.DevOps.Dialogflow.Tests/DialogflowNLUTestClientTests.cs
@@ -24,6 +24,21 @@ namespace NLU.DevOps.Dialogflow.Tests
     {
         private const double Epsilon = 1e-6;
 
+        private static TimeSpan originalThrottle;
+
+        [OneTimeSetUp]
+        public static void SetUp()
+        {
+            originalThrottle = DialogflowNLUTestClient.ThrottleQueryDelay;
+            DialogflowNLUTestClient.ThrottleQueryDelay = TimeSpan.FromMilliseconds(100);
+        }
+
+        [OneTimeTearDown]
+        public static void TearDown()
+        {
+            DialogflowNLUTestClient.ThrottleQueryDelay = originalThrottle;
+        }
+
         [Test]
         public static void ThrowsArgumentNull()
         {

--- a/src/NLU.DevOps.Dialogflow/DialogflowNLUTestClient.cs
+++ b/src/NLU.DevOps.Dialogflow/DialogflowNLUTestClient.cs
@@ -29,9 +29,6 @@ namespace NLU.DevOps.Dialogflow
         private const string DialogflowProjectIdConfigurationKey = "dialogflowProjectId";
         private const string DialogflowSessionIdConfigurationKey = "dialogflowSessionId";
 
-        // Dialogflow typically limits the number of requests per minute, so setting a retry delay to 30 seconds.
-        private static readonly TimeSpan ThrottleQueryDelay = TimeSpan.FromSeconds(30);
-
         private SessionsClient sessionsClient;
 
         public DialogflowNLUTestClient(SessionsClient sessionsClient, IConfiguration configuration)
@@ -44,6 +41,9 @@ namespace NLU.DevOps.Dialogflow
         {
             this.Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         }
+
+        // Dialogflow typically limits the number of requests per minute, so setting a retry delay to 30 seconds.
+        internal static TimeSpan ThrottleQueryDelay { get; set; } = TimeSpan.FromSeconds(30);
 
         private static ILogger Logger => LazyLogger.Value;
 


### PR DESCRIPTION
The current Dialogflow retry delay of 30 seconds is causing a significant delay when running unit tests that exercise that retry delay. This change allows the delay duration to be overridden.