### PR TITLE
Fixes bug for empty entity dictionary

### DIFF
--- a/src/NLU.DevOps.LuisV3/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.LuisV3/LuisNLUTestClient.cs
@@ -97,7 +97,7 @@ namespace NLU.DevOps.Luis
 
         private static IEnumerable<Entity> GetEntities(string utterance, IDictionary<string, object> entities)
         {
-            if (entities == null)
+            if (entities == null || entities.Count == 0)
             {
                 return null;
             }
@@ -148,8 +148,12 @@ namespace NLU.DevOps.Luis
                     .WithScore(score);
             }
 
-            var globalMetadata = entities["$instance"] as JToken;
-            if (globalMetadata == null)
+            var globalMetadata = default(JToken);
+            if (entities.TryGetValue("$instance", out var globalMetadataValue))
+            {
+                globalMetadata = globalMetadataValue as JToken;
+            }
+            else
             {
                 throw new InvalidOperationException("Expected top-level metadata for entities.");
             }

--- a/src/NLU.DevOps.LuisV3/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.LuisV3/LuisNLUTestClient.cs
@@ -149,9 +149,9 @@ namespace NLU.DevOps.Luis
             }
 
             var globalMetadata = default(JToken);
-            if (entities.TryGetValue("$instance", out var globalMetadataValue))
+            if (entities.TryGetValue("$instance", out var metadataValue) && metadataValue is JToken metadataJson)
             {
-                globalMetadata = globalMetadataValue as JToken;
+                globalMetadata = metadataJson;
             }
             else
             {


### PR DESCRIPTION
Previously, we were only checking for a null entity dictionary when skipping parsing for LUIS v3 entities. This change also skips for empty entity dictionaries and makes the error more explicit when top-level entity metadata is not included in the response.

Fixes #293