### PR TITLE
Adds support for YAML test settings

### DIFF
--- a/src/NLU.DevOps.ModelPerformance.Tests/TestSettingsTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestSettingsTests.cs
@@ -36,11 +36,35 @@ namespace NLU.DevOps.ModelPerformance.Tests
 
             try
             {
-                var configuration = new ConfigurationBuilder()
-                    .AddJsonFile(settingsFile)
-                    .Build();
+                var testSettings = new TestSettings(settingsFile, false);
+                testSettings.TrueNegativeIntent.Should().Be("default");
+                testSettings.StrictEntities.Should().BeEquivalentTo("strict");
+                testSettings.IgnoreEntities.Should().BeEquivalentTo("ignore");
+            }
+            finally
+            {
+                File.Delete(settingsFile);
+            }
+        }
 
-                var testSettings = new TestSettings(configuration, false);
+        [Test]
+        public static void CreateFromYaml()
+        {
+            var settingsFile = $"{Guid.NewGuid().ToString()}.yml";
+            var settings = new[]
+            {
+                "trueNegativeIntent: default",
+                "strictEntities:",
+                "- strict",
+                "ignoreEntities:",
+                "- ignore",
+            };
+
+            File.WriteAllText(settingsFile, string.Join(Environment.NewLine, settings));
+
+            try
+            {
+                var testSettings = new TestSettings(settingsFile, false);
                 testSettings.TrueNegativeIntent.Should().Be("default");
                 testSettings.StrictEntities.Should().BeEquivalentTo("strict");
                 testSettings.IgnoreEntities.Should().BeEquivalentTo("ignore");

--- a/src/NLU.DevOps.ModelPerformance/NLU.DevOps.ModelPerformance.csproj
+++ b/src/NLU.DevOps.ModelPerformance/NLU.DevOps.ModelPerformance.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+    <PackageReference Include="NetEscapades.Configuration.Yaml" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NLU.DevOps.ModelPerformance/TestSettings.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestSettings.cs
@@ -7,6 +7,7 @@ namespace NLU.DevOps.ModelPerformance
     using System.Collections.Generic;
     using System.IO;
     using Microsoft.Extensions.Configuration;
+    using NetEscapades.Configuration.Yaml;
 
     /// <summary>
     /// A wrapper class to expose test configuration values.
@@ -66,7 +67,12 @@ namespace NLU.DevOps.ModelPerformance
         {
             IConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
 
-            if (path != null)
+            if (path != null && (path.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) || path.EndsWith(".yml", StringComparison.OrdinalIgnoreCase)))
+            {
+                configurationBuilder = configurationBuilder
+                    .AddYamlFile(Path.Combine(Directory.GetCurrentDirectory(), path));
+            }
+            else if (path != null)
             {
                 configurationBuilder = configurationBuilder
                     .AddJsonFile(Path.Combine(Directory.GetCurrentDirectory(), path));


### PR DESCRIPTION
In addition to supporting JSON test settings, this change adds support for YAML test settings for the `compare` command.