### PR TITLE
Adds support for endpoints based on Azure resource

### DIFF
--- a/docs/AzurePipelines.md
+++ b/docs/AzurePipelines.md
@@ -78,7 +78,7 @@ Add the following task to your Azure Pipeline:
 
 You'll need to configure an Azure service principal as a [service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=vsts) and set the name of the service connection to the `azureSubscription` variable.
 
-Also be sure to set the [`azureSubscriptionId`](LuisEndpointConfiguration.md#azuresubscriptionid), [`azureResourceGroup`](LuisEndpointConfiguration.md#azureresourcegroup), [`azureLuisResourceName`](LuisEndpointConfiguration.md#azureluisresourcename), [`luisEndpointKey`](LuisEndpointConfiguration.md#luisendpointkey) and [`luisEndpointRegion`](LuisEndpointConfiguration.md#luisendpointregion) variables.
+Also be sure to set the [`azureSubscriptionId`](LuisEndpointConfiguration.md#azuresubscriptionid), [`azureResourceGroup`](LuisEndpointConfiguration.md#azureresourcegroup), [`luisPredictionResourceName`](LuisEndpointConfiguration.md#luisPredictionResourceName), and [`luisEndpointKey`](LuisEndpointConfiguration.md#luisendpointkey).
 
 ### Train the LUIS model
 

--- a/docs/LuisEndpointConfiguration.md
+++ b/docs/LuisEndpointConfiguration.md
@@ -34,6 +34,7 @@ This will allow you to call the `train` sub-command for LUIS (see [Training an N
 Options to consider for training a LUIS model include:
 
 - [`luisAuthoringKey`](#luisauthoringkey)
+- [`luisAuthoringResourceName`](#luisauthoringresourcename)
 - [`luisAuthoringRegion`](#luisauthoringregion)
 - [`luisAppId`](#luisappid)
 - [`luisIsStaging`](#luisisstaging)
@@ -82,10 +83,11 @@ Also note that the LUIS authoring key has a [quota](https://docs.microsoft.com/e
 Options to consider for testing a LUIS model include:
 
 - [`luisAuthoringKey`](#luisauthoringkey)
+- [`luisAuthoringResourceName`](#luisauthoringresourcename)
 - [`luisAuthoringRegion`](#luisauthoringregion)
 - [`luisEndpointKey`](#luisendpointkey)
-- [`luisEndpointRegion`](#luisendpointregion)
 - [`luisPredictionResourceName`](#luispredictionresourcename)
+- [`luisEndpointRegion`](#luisendpointregion)
 - [`luisAppId`](#luisappid)
 - [`luisIsStaging`](#luisIsStaging)
 - [`luisSlotName`](#luisslotname)
@@ -140,6 +142,7 @@ To simplify the configuration process in continuous integration scenarios, you c
 Options to consider for tearing down a LUIS model include:
 
 - [`luisAuthoringKey`](#luisauthoringkey)
+- [`luisAuthoringResourceName`](#luisauthoringresourcename)
 - [`luisAuthoringRegion`](#luisauthoringregion)
 - [`luisAppId`](#luisappid)
 - [`luisAppCreated`](#luisappcreated)
@@ -203,10 +206,15 @@ Options to consider for assigning an Azure resource during training:
 
 Required for `train` and `clean`. May be used (to a limited extent subject to [quota](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-boundaries#key-limits)) for `test` from text.
 
+### `luisAuthoringResourceName`
+(Optional) Azure LUIS authoring resource name.
+
+Required for `train` and `clean` if [`luisAuthoringRegion`](#luisauthoringregion) not specified. May be used (to a limited extent subject to [quota](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-boundaries#key-limits)) for `test` from text.
+
 ### `luisAuthoringRegion`
 (Optional) LUIS authoring region.
 
-Required for `train` and `clean`. May be used (to a limited extent subject to [quota](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-boundaries#key-limits)) for `test` from text.
+Required for `train` and `clean` if [`luisAuthoringResourceName`](#luisauthoringresourcename) not specified. May be used (to a limited extent subject to [quota](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-boundaries#key-limits)) for `test` from text. 
 
 ### `luisEndpointKey`
 (Optional) LUIS endpoint key.
@@ -216,7 +224,7 @@ Optional for `test`. If not specified, [`luisAuthoringKey`](#luisauthoringkey) w
 ### `luisEndpointRegion`
 (Optional) LUIS endpoint region.
 
-Optional for `test`. If not specified, [`luisAuthoringRegion`](#luisauthoringregion) will be used.
+Optional for `test`. If not specified, one of [`luisPredictionResourceName`](#luispredictionresourcename), [`luisAuthoringResourceName`](#luisauthoringresourcename), or [`luisAuthoringRegion`](#luisauthoringregion) will be used.
 
 ### `luisAppId`
 (Optional) The LUIS app ID.
@@ -312,7 +320,7 @@ Optional for `train`. When supplied along with [`azureSubscriptionId`](#azuresub
 ### `luisPredictionResourceName`
 (Optional) Azure LUIS prediction resource name.
 
-Optional for `train` and `test`. For `train`, when supplied along with [`azureSubscriptionId`](#azuresubscriptionid), [`azureResourceGroup`](#azureresourcegroup), and [`ARM_TOKEN`](#arm_token), the CLI tool will assign an Azure LUIS resource to the LUIS app. See [Configuring Azure resource assignment](#configuration-for-azure-resource-assignment) for more details. If not specified for `test`, NLU.DevOps will fallback on the [`luisEndpointRegion`](#luisendpointregion) or [`luisAuthoringRegion`](#luisauthoringregion).
+Optional for `train` and `test`. For `train`, when supplied along with [`azureSubscriptionId`](#azuresubscriptionid), [`azureResourceGroup`](#azureresourcegroup), and [`ARM_TOKEN`](#arm_token), the CLI tool will assign an Azure LUIS resource to the LUIS app. See [Configuring Azure resource assignment](#configuration-for-azure-resource-assignment) for more details. If not specified for `test`, the implementation will fallback on the [`luisEndpointRegion`](#luisendpointregion), [`luisAuthoringResourceName`](#luisauthoringresourcename), or [`luisAuthoringRegion`](#luisauthoringregion).
 
 ### `ARM_TOKEN`
 (Optional) ARM token for authorizing Azure requests.

--- a/docs/LuisEndpointConfiguration.md
+++ b/docs/LuisEndpointConfiguration.md
@@ -77,7 +77,7 @@ This will allow you to call the `test` sub-command for LUIS (see [Testing an NLU
 
 To simplify the configuration process in continuous integration scenarios, you can use the [`--save-appsettings`](Train.md#-a---save-appsettings) option to save the LUIS app ID generated from a previous call to `train` in a `appsettings.luis.json` file.
 
-Also note that the LUIS authoring key has a [quota](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-boundaries#key-limits) when used for query (up to 1,000 text queries/month and at most 5 requests/second). As such it is recommended that you suppy a [`luisEndpointKey`](#luisendpointkey) and [`luisEndpointRegion`](#luisendpointregion). You may not use the [`luisAuthoringKey`](#luisauthoringkey) for testing with the [`--speech`](Test.md#--speech) option, unless you also supply a [`speechKey`](#speechkey). See [Configuring Azure resource assignment](#configuration-for-azure-resource-assignment) for details on how to avoid the quota.
+Also note that the LUIS authoring key has a [quota](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-boundaries#key-limits) when used for query (up to 1,000 text queries/month and at most 5 requests/second). As such it is recommended that you suppy a [`luisEndpointKey`](#luisendpointkey) and [`luisPredictionResourceName`](#luispredictionresourcename) or [`luisEndpointRegion`](#luisendpointregion). You may not use the [`luisAuthoringKey`](#luisauthoringkey) for testing with the [`--speech`](Test.md#--speech) option, unless you also supply a [`speechKey`](#speechkey). See [Configuring Azure resource assignment](#configuration-for-azure-resource-assignment) for details on how to avoid the quota.
 
 Options to consider for testing a LUIS model include:
 
@@ -85,6 +85,7 @@ Options to consider for testing a LUIS model include:
 - [`luisAuthoringRegion`](#luisauthoringregion)
 - [`luisEndpointKey`](#luisendpointkey)
 - [`luisEndpointRegion`](#luisendpointregion)
+- [`luisPredictionResourceName`](#luispredictionresourcename)
 - [`luisAppId`](#luisappid)
 - [`luisIsStaging`](#luisIsStaging)
 - [`luisSlotName`](#luisslotname)
@@ -165,7 +166,7 @@ Within an `appsettings.luis.json` file use the following:
 {
   "azureSubscriptionId": "00000000-0000-0000-0000-000000000000",
   "azureResourceGroup": "...",
-  "azureLuisResourceName": "...",
+  "luisPredictionResourceName": "...",
   "ARM_TOKEN": "..."
 }
 ```
@@ -175,7 +176,7 @@ If using environment variables set the values (example shown using Powershell):
 ```powershell
 $env:azureSubscriptionId='00000000-0000-0000-0000-000000000000'
 $env:azureResourceGroup='...'
-$env:azureLuisResourceName='...'
+$env:luisPredictionResourceName='...'
 $env:ARM_TOKEN='...'
 ```
 
@@ -184,7 +185,7 @@ Example below uses the export command to create environment variables on a Mac:
 ```vim
 azureSubscriptionId='00000000-0000-0000-0000-000000000000'
 export azureResourceGroup='...'
-export azureLuisResourceName='...'
+export luisPredictionResourceName='...'
 export ARM_TOKEN='...'
 ```
 
@@ -192,7 +193,7 @@ Options to consider for assigning an Azure resource during training:
 
 - [`azureSubscriptionId`](#azuresubscriptionid)
 - [`azureResourceGroup`](#azureresourcegroup)
-- [`azureLuisResourceName`](#azureluisresourcename)
+- [`luisPredictionResourceName`](#luisPredictionResourceName)
 - [`ARM_TOKEN`](#arm_token)
 
 ## App Settings Variables
@@ -301,22 +302,22 @@ This option is only used for LUIS v2 (i.e., when using `--service luis`).
 ### `azureSubscriptionId`
 (Optional) Azure subscription ID.
 
-Optional for `train`. When supplied along with [`azureResourceGroup`](#azureresourcegroup), [`azureLuisResourceName`](#azureluisresourcename), and [`ARM_TOKEN`](#arm_token), the CLI tool will assign an Azure LUIS resource to the LUIS app. See [Configuring Azure resource assignment](#configuration-for-azure-resource-assignment) for more details.
+Optional for `train`. When supplied along with [`azureResourceGroup`](#azureresourcegroup), [`luisPredictionResourceName`](#luisPredictionResourceName), and [`ARM_TOKEN`](#arm_token), the CLI tool will assign an Azure LUIS resource to the LUIS app. See [Configuring Azure resource assignment](#configuration-for-azure-resource-assignment) for more details.
 
 ### `azureResourceGroup`
 (Optional) Azure resource group containing the LUIS resource.
 
-Optional for `train`. When supplied along with [`azureSubscriptionId`](#azuresubscriptionid), [`azureLuisResourceName`](#azureluisresourcename), and [`ARM_TOKEN`](#arm_token), the CLI tool will assign an Azure LUIS resource to the LUIS app. See [Configuring Azure resource assignment](#configuration-for-azure-resource-assignment) for more details.
+Optional for `train`. When supplied along with [`azureSubscriptionId`](#azuresubscriptionid), [`luisPredictionResourceName`](#luisPredictionResourceName), and [`ARM_TOKEN`](#arm_token), the CLI tool will assign an Azure LUIS resource to the LUIS app. See [Configuring Azure resource assignment](#configuration-for-azure-resource-assignment) for more details.
 
-### `azureLuisResourceName`
-(Optional) Azure LUIS resource name.
+### `luisPredictionResourceName`
+(Optional) Azure LUIS prediction resource name.
 
-Optional for `train`. When supplied along with [`azureSubscriptionId`](#azuresubscriptionid), [`azureResourceGroup`](#azureresourcegroup), and [`ARM_TOKEN`](#arm_token), the CLI tool will assign an Azure LUIS resource to the LUIS app. See [Configuring Azure resource assignment](#configuration-for-azure-resource-assignment) for more details.
+Optional for `train` and `test`. For `train`, when supplied along with [`azureSubscriptionId`](#azuresubscriptionid), [`azureResourceGroup`](#azureresourcegroup), and [`ARM_TOKEN`](#arm_token), the CLI tool will assign an Azure LUIS resource to the LUIS app. See [Configuring Azure resource assignment](#configuration-for-azure-resource-assignment) for more details. If not specified for `test`, NLU.DevOps will fallback on the [`luisEndpointRegion`](#luisendpointregion) or [`luisAuthoringRegion`](#luisauthoringregion).
 
 ### `ARM_TOKEN`
 (Optional) ARM token for authorizing Azure requests.
 
-Optional for `train`. When supplied along with [`azureSubscriptionId`](#azuresubscriptionid), [`azureResourceGroup`](#azureresourcegroup), and [`azureLuisResourceName`](#azureluisresourcename), the CLI tool will assign an Azure LUIS resource to the LUIS app. See [Configuring Azure resource assignment](#configuration-for-azure-resource-assignment) for more details.
+Optional for `train`. When supplied along with [`azureSubscriptionId`](#azuresubscriptionid), [`azureResourceGroup`](#azureresourcegroup), and [`luisPredictionResourceName`](#luisPredictionResourceName), the CLI tool will assign an Azure LUIS resource to the LUIS app. See [Configuring Azure resource assignment](#configuration-for-azure-resource-assignment) for more details.
 
 ## Additional Information
 

--- a/src/CodeCoverage.props
+++ b/src/CodeCoverage.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.3.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/NLU.DevOps.Luis.Shared/AzureSubscriptionInfo.cs
+++ b/src/NLU.DevOps.Luis.Shared/AzureSubscriptionInfo.cs
@@ -25,7 +25,7 @@ namespace NLU.DevOps.Luis
         {
             if (luisConfiguration.AzureSubscriptionId == null
                 || luisConfiguration.AzureResourceGroup == null
-                || luisConfiguration.AzureAppName == null
+                || luisConfiguration.PredictionResourceName == null
                 || luisConfiguration.ArmToken == null)
             {
                 return null;
@@ -34,7 +34,7 @@ namespace NLU.DevOps.Luis
             return new AzureSubscriptionInfo(
                 luisConfiguration.AzureSubscriptionId,
                 luisConfiguration.AzureResourceGroup,
-                luisConfiguration.AzureAppName);
+                luisConfiguration.PredictionResourceName);
         }
     }
 }

--- a/src/NLU.DevOps.Luis.Shared/ILuisConfiguration.cs
+++ b/src/NLU.DevOps.Luis.Shared/ILuisConfiguration.cs
@@ -26,19 +26,24 @@ namespace NLU.DevOps.Luis
         string AuthoringKey { get; }
 
         /// <summary>
-        /// Gets the LUIS authoring region.
+        /// Gets the LUIS authoring endpoint.
         /// </summary>
-        string AuthoringRegion { get; }
+        string AuthoringEndpoint { get; }
 
         /// <summary>
-        /// Gets the LUIS endpoint key.
+        /// Gets the LUIS prediction key.
         /// </summary>
-        string EndpointKey { get; }
+        string PredictionKey { get; }
 
         /// <summary>
-        /// Gets the LUIS endpoint region.
+        /// Gets the LUIS prediction endpoint.
         /// </summary>
-        string EndpointRegion { get; }
+        string PredictionEndpoint { get; }
+
+        /// <summary>
+        /// Gets the LUIS prediction resource name.
+        /// </summary>
+        string PredictionResourceName { get; }
 
         /// <summary>
         /// Gets the LUIS version ID.
@@ -69,25 +74,26 @@ namespace NLU.DevOps.Luis
         /// Gets the Cognitive Services speech endpoint.
         /// </summary>
         Uri SpeechEndpoint { get; }
-#if LUIS_V2
 
+#if LUIS_V2
         /// <summary>
         /// Gets a value indicating whether the REST speech endpoint should be used as opposed to the Speech SDK.
         /// </summary>
         bool UseSpeechEndpoint { get; }
+
 #endif
 #if LUIS_V3
-
         /// <summary>
         /// Gets the LUIS staging name.
         /// </summary>
         string SlotName { get; }
 
+#endif
+
         /// <summary>
         /// Gets a value indicating whether the LUIS model should use direct version publish.
         /// </summary>
         bool DirectVersionPublish { get; }
-#endif
 
         /// <summary>
         /// Gets the Azure resource group.
@@ -98,11 +104,6 @@ namespace NLU.DevOps.Luis
         /// Gets the Azure subscription ID.
         /// </summary>
         string AzureSubscriptionId { get; }
-
-        /// <summary>
-        /// Gets the Azure Cognitive Services app name.
-        /// </summary>
-        string AzureAppName { get; }
 
         /// <summary>
         /// Gets the ARM token.

--- a/src/NLU.DevOps.Luis.Tests.Shared/LuisConfigurationTests.cs
+++ b/src/NLU.DevOps.Luis.Tests.Shared/LuisConfigurationTests.cs
@@ -91,44 +91,36 @@ namespace NLU.DevOps.Luis.Tests
         }
 
         [Test]
-        [TestCase(nameof(ILuisConfiguration.AuthoringEndpoint), "luisAuthoringRegion")]
-        [TestCase(nameof(ILuisConfiguration.PredictionEndpoint), "luisAuthoringRegion")]
-        [TestCase(nameof(ILuisConfiguration.PredictionEndpoint), "luisEndpointRegion")]
-        public static void CreatesEndpointFromRegion(string propertyName, string configurationKey)
+        [TestCase(nameof(ILuisConfiguration.AuthoringEndpoint), "luisAuthoringResourceName", "https://{0}.cognitiveservices.azure.com", "luisAuthoringRegion")]
+        [TestCase(nameof(ILuisConfiguration.PredictionEndpoint), "luisAuthoringResourceName", "https://{0}.cognitiveservices.azure.com", "luisAuthoringRegion")]
+        [TestCase(nameof(ILuisConfiguration.PredictionEndpoint), "luisAuthoringResourceName", "https://{0}.cognitiveservices.azure.com", "luisEndpointRegion")]
+        [TestCase(nameof(ILuisConfiguration.PredictionEndpoint), "luisPredictionResourceName", "https://{0}.cognitiveservices.azure.com", "luisEndpointRegion")]
+        [TestCase(nameof(ILuisConfiguration.PredictionEndpoint), "luisPredictionResourceName", "https://{0}.cognitiveservices.azure.com", "luisAuthoringResourceName")]
+        [TestCase(nameof(ILuisConfiguration.PredictionEndpoint), "luisPredictionResourceName", "https://{0}.cognitiveservices.azure.com", "luisAuthoringRegion")]
+        [TestCase(nameof(ILuisConfiguration.AuthoringEndpoint), "luisAuthoringRegion", "https://{0}.api.cognitive.microsoft.com", "ignore")]
+        [TestCase(nameof(ILuisConfiguration.PredictionEndpoint), "luisAuthoringRegion", "https://{0}.api.cognitive.microsoft.com", "ignore")]
+        [TestCase(nameof(ILuisConfiguration.PredictionEndpoint), "luisEndpointRegion", "https://{0}.api.cognitive.microsoft.com", "luisAuthoringRegion")]
+        public static void CreatesEndpointFromRegion(string propertyName, string configurationKey, string template, string otherKey)
         {
             var configuration = new ConfigurationBuilder()
                .AddInMemoryCollection(new Dictionary<string, string>
                {
                    { configurationKey, Guid.NewGuid().ToString() },
+                   { otherKey, Guid.NewGuid().ToString() },
                })
                .Build();
 
             var luisConfiguration = new LuisConfiguration(configuration);
             var property = typeof(LuisConfiguration).GetProperty(propertyName);
             var propertyValue = property.GetValue(luisConfiguration);
-            propertyValue.Should().Be($"https://{configuration[configurationKey]}.api.cognitive.microsoft.com");
-        }
-
-        [Test]
-        public static void CreatesPredictionEndpointFromPredictionResourceName()
-        {
-            var name = Guid.NewGuid().ToString();
-            var configuration = new ConfigurationBuilder()
-               .AddInMemoryCollection(new Dictionary<string, string>
-               {
-                   { "luisPredictionResourceName", name },
-               })
-               .Build();
-
-            var luisConfiguration = new LuisConfiguration(configuration);
-            luisConfiguration.PredictionEndpoint.Should().Be($"https://{name}.cognitiveservices.azure.com");
+            propertyValue.Should().Be(string.Format(CultureInfo.InvariantCulture, template, configuration[configurationKey]));
         }
 
         [Test]
         [TestCase(nameof(ILuisConfiguration.AuthoringKey), "luisAuthoringKey")]
-        [TestCase(nameof(ILuisConfiguration.AuthoringEndpoint), "luisAuthoringRegion")]
+        [TestCase(nameof(ILuisConfiguration.AuthoringEndpoint), "luisAuthoringResourceName", "luisAuthoringRegion")]
         [TestCase(nameof(ILuisConfiguration.PredictionKey), "luisEndpointKey", "luisAuthoringKey")]
-        [TestCase(nameof(ILuisConfiguration.PredictionEndpoint), "luisPredictionResourceName", "luisEndpointRegion", "luisAuthoringRegion")]
+        [TestCase(nameof(ILuisConfiguration.PredictionEndpoint), "luisPredictionResourceName", "luisAuthoringResourceName", "luisEndpointRegion", "luisAuthoringRegion")]
         [TestCase(nameof(ILuisConfiguration.SpeechRegion), "speechRegion", "luisEndpointRegion")]
         [TestCase(nameof(ILuisConfiguration.SpeechKey), "speechKey")]
         public static void ThrowsInvalidOperationForMissingConfiguration(string propertyName, params string[] configurationKeys)

--- a/src/NLU.DevOps.Luis.Tests.Shared/LuisConfigurationTests.cs
+++ b/src/NLU.DevOps.Luis.Tests.Shared/LuisConfigurationTests.cs
@@ -26,16 +26,15 @@ namespace NLU.DevOps.Luis.Tests
         [TestCase(nameof(ILuisConfiguration.AppId), "luisAppId")]
         [TestCase(nameof(ILuisConfiguration.VersionId), "luisVersionId")]
         [TestCase(nameof(ILuisConfiguration.AuthoringKey), "luisAuthoringKey")]
-        [TestCase(nameof(ILuisConfiguration.AuthoringRegion), "luisAuthoringRegion")]
-        [TestCase(nameof(ILuisConfiguration.EndpointKey), "luisEndpointKey")]
-        [TestCase(nameof(ILuisConfiguration.EndpointRegion), "luisEndpointRegion")]
+        [TestCase(nameof(ILuisConfiguration.PredictionKey), "luisEndpointKey")]
 #if LUIS_V3
         [TestCase(nameof(ILuisConfiguration.SlotName), "luisSlotName")]
 #endif
         [TestCase(nameof(ILuisConfiguration.SpeechKey), "speechKey")]
         [TestCase(nameof(ILuisConfiguration.AzureSubscriptionId), "azureSubscriptionId")]
         [TestCase(nameof(ILuisConfiguration.AzureResourceGroup), "azureResourceGroup")]
-        [TestCase(nameof(ILuisConfiguration.AzureAppName), "azureLuisResourceName")]
+        [TestCase(nameof(ILuisConfiguration.PredictionResourceName), "luisPredictionResourceName")]
+        [TestCase(nameof(ILuisConfiguration.PredictionResourceName), "azureLuisResourceName")]
         [TestCase(nameof(ILuisConfiguration.ArmToken), "ARM_TOKEN")]
         public static void ReadsStringConfigurationValues(string propertyName, string configurationKey)
         {
@@ -54,11 +53,9 @@ namespace NLU.DevOps.Luis.Tests
 
         [Test]
         [TestCase(nameof(ILuisConfiguration.IsStaging), "luisIsStaging")]
+        [TestCase(nameof(ILuisConfiguration.DirectVersionPublish), "luisDirectVersionPublish")]
 #if LUIS_V2
         [TestCase(nameof(ILuisConfiguration.UseSpeechEndpoint), "luisUseSpeechEndpoint")]
-#endif
-#if LUIS_V3
-        [TestCase(nameof(ILuisConfiguration.DirectVersionPublish), "luisDirectVersionPublish")]
 #endif
         public static void ReadsBooleanConfigurationValues(string propertyName, string configurationKey)
         {
@@ -94,10 +91,44 @@ namespace NLU.DevOps.Luis.Tests
         }
 
         [Test]
+        [TestCase(nameof(ILuisConfiguration.AuthoringEndpoint), "luisAuthoringRegion")]
+        [TestCase(nameof(ILuisConfiguration.PredictionEndpoint), "luisAuthoringRegion")]
+        [TestCase(nameof(ILuisConfiguration.PredictionEndpoint), "luisEndpointRegion")]
+        public static void CreatesEndpointFromRegion(string propertyName, string configurationKey)
+        {
+            var configuration = new ConfigurationBuilder()
+               .AddInMemoryCollection(new Dictionary<string, string>
+               {
+                   { configurationKey, Guid.NewGuid().ToString() },
+               })
+               .Build();
+
+            var luisConfiguration = new LuisConfiguration(configuration);
+            var property = typeof(LuisConfiguration).GetProperty(propertyName);
+            var propertyValue = property.GetValue(luisConfiguration);
+            propertyValue.Should().Be($"https://{configuration[configurationKey]}.api.cognitive.microsoft.com");
+        }
+
+        [Test]
+        public static void CreatesPredictionEndpointFromPredictionResourceName()
+        {
+            var name = Guid.NewGuid().ToString();
+            var configuration = new ConfigurationBuilder()
+               .AddInMemoryCollection(new Dictionary<string, string>
+               {
+                   { "luisPredictionResourceName", name },
+               })
+               .Build();
+
+            var luisConfiguration = new LuisConfiguration(configuration);
+            luisConfiguration.PredictionEndpoint.Should().Be($"https://{name}.cognitiveservices.azure.com");
+        }
+
+        [Test]
         [TestCase(nameof(ILuisConfiguration.AuthoringKey), "luisAuthoringKey")]
-        [TestCase(nameof(ILuisConfiguration.AuthoringRegion), "luisAuthoringRegion")]
-        [TestCase(nameof(ILuisConfiguration.EndpointKey), "luisEndpointKey", "luisAuthoringKey")]
-        [TestCase(nameof(ILuisConfiguration.EndpointRegion), "luisEndpointRegion", "luisAuthoringRegion")]
+        [TestCase(nameof(ILuisConfiguration.AuthoringEndpoint), "luisAuthoringRegion")]
+        [TestCase(nameof(ILuisConfiguration.PredictionKey), "luisEndpointKey", "luisAuthoringKey")]
+        [TestCase(nameof(ILuisConfiguration.PredictionEndpoint), "luisPredictionResourceName", "luisEndpointRegion", "luisAuthoringRegion")]
         [TestCase(nameof(ILuisConfiguration.SpeechRegion), "speechRegion", "luisEndpointRegion")]
         [TestCase(nameof(ILuisConfiguration.SpeechKey), "speechKey")]
         public static void ThrowsInvalidOperationForMissingConfiguration(string propertyName, params string[] configurationKeys)
@@ -118,7 +149,7 @@ namespace NLU.DevOps.Luis.Tests
         [TestCase(nameof(ILuisConfiguration.AppId))]
         [TestCase(nameof(ILuisConfiguration.AzureSubscriptionId))]
         [TestCase(nameof(ILuisConfiguration.AzureResourceGroup))]
-        [TestCase(nameof(ILuisConfiguration.AzureAppName))]
+        [TestCase(nameof(ILuisConfiguration.PredictionResourceName))]
         [TestCase(nameof(ILuisConfiguration.ArmToken))]
         public static void EmptyConfigurationReturnsNullValue(string propertyName)
         {

--- a/src/NLU.DevOps.Luis/LuisTestClient.cs
+++ b/src/NLU.DevOps.Luis/LuisTestClient.cs
@@ -21,19 +21,16 @@ namespace NLU.DevOps.Luis
 
     internal sealed class LuisTestClient : ILuisTestClient
     {
-        private const string Protocol = "https://";
-        private const string Domain = ".api.cognitive.microsoft.com";
-
         private static readonly TimeSpan ThrottleQueryDelay = TimeSpan.FromMilliseconds(100);
 
         public LuisTestClient(ILuisConfiguration luisConfiguration)
         {
             this.LuisConfiguration = luisConfiguration ?? throw new ArgumentNullException(nameof(luisConfiguration));
 
-            var endpointCredentials = new ApiKeyServiceClientCredentials(luisConfiguration.EndpointKey);
+            var endpointCredentials = new ApiKeyServiceClientCredentials(luisConfiguration.PredictionKey);
             this.RuntimeClient = new LUISRuntimeClient(endpointCredentials)
             {
-                Endpoint = $"{Protocol}{luisConfiguration.EndpointRegion}{Domain}",
+                Endpoint = luisConfiguration.PredictionEndpoint,
             };
         }
 

--- a/src/NLU.DevOps.LuisV3/LuisTestClient.cs
+++ b/src/NLU.DevOps.LuisV3/LuisTestClient.cs
@@ -17,18 +17,15 @@ namespace NLU.DevOps.Luis
 
     internal sealed class LuisTestClient : ILuisTestClient
     {
-        private const string Protocol = "https://";
-        private const string Domain = ".api.cognitive.microsoft.com";
-
         private static readonly TimeSpan ThrottleQueryDelay = TimeSpan.FromMilliseconds(100);
 
         public LuisTestClient(ILuisConfiguration luisConfiguration)
         {
             this.LuisConfiguration = luisConfiguration ?? throw new ArgumentNullException(nameof(luisConfiguration));
-            var endpointCredentials = new ApiKeyServiceClientCredentials(luisConfiguration.EndpointKey);
+            var endpointCredentials = new ApiKeyServiceClientCredentials(luisConfiguration.PredictionKey);
             this.RuntimeClient = new LUISRuntimeClient(endpointCredentials)
             {
-                Endpoint = $"{Protocol}{luisConfiguration.EndpointRegion}{Domain}",
+                Endpoint = luisConfiguration.PredictionEndpoint,
             };
         }
 


### PR DESCRIPTION
Adds functionality to set the prediction endpoint based on the Azure LUIS prediction resource instead of the endpoint region. Keeps functionality in place to fallback on the endpoint region if specified.

Fixes #298