### PR TITLE
Adds option to customize the regression metric

### DIFF
--- a/src/NLU.DevOps.ModelPerformance.Tests/NLUAccuracyTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/NLUAccuracyTests.cs
@@ -26,7 +26,43 @@ namespace NLU.DevOps.ModelPerformance.Tests
             matrix.Precision().Should().BeApproximately(0.5652, 0.0001);
             matrix.Recall().Should().BeApproximately(0.2241, 0.0001);
             matrix.F1().Should().BeApproximately(0.3210, 0.0001);
+            matrix.FScore(2).Should().BeApproximately(0.2549, 0.0001);
             matrix.Total().Should().Be(68);
+        }
+
+        [Test]
+        public static void GetPrecisionMetric()
+        {
+            var matrix = new ConfusionMatrix(1, 0, 1, 0);
+            matrix.GetMetric("precision").Should().Be(matrix.Precision());
+        }
+
+        [Test]
+        public static void GetRecallMetric()
+        {
+            var matrix = new ConfusionMatrix(1, 0, 1, 0);
+            matrix.GetMetric("recall").Should().Be(matrix.Recall());
+        }
+
+        [Test]
+        public static void GetFMeasureMetric()
+        {
+            var matrix = new ConfusionMatrix(1, 0, 1, 0);
+            matrix.GetMetric("f2").Should().Be(matrix.FScore(2));
+        }
+
+        [Test]
+        public static void GetFMeasureMetricDecimal()
+        {
+            var matrix = new ConfusionMatrix(1, 0, 1, 0);
+            matrix.GetMetric("f0.5").Should().Be(matrix.FScore(0.5));
+        }
+
+        [Test]
+        public static void GetDefaultMetricAsF1()
+        {
+            var matrix = new ConfusionMatrix(1, 0, 1, 0);
+            matrix.GetMetric(null).Should().Be(matrix.F1());
         }
     }
 }

--- a/src/NLU.DevOps.ModelPerformance/NLUThreshold.cs
+++ b/src/NLU.DevOps.ModelPerformance/NLUThreshold.cs
@@ -22,5 +22,10 @@ namespace NLU.DevOps.ModelPerformance
         /// Gets or sets the threshold.
         /// </summary>
         public double Threshold { get; set; }
+
+        /// <summary>
+        /// Gets or sets the comparison metric.
+        /// </summary>
+        public string Metric { get; set; }
     }
 }


### PR DESCRIPTION
This change allows customization of the metric used to check for performance regressions. For example, if a user wants to set a threshold for regression targeted only at precision, recall or a custom F-score, they can add the `metric` property to their threshold configuration in the compare test settings. The valid values are `precision`, `recall` or `f(\d+)(.\d+)?` (e.g., `f0.5`).

Fixes #313