### PR TITLE
Fixes minor issues in CLI experience

### DIFF
--- a/src/NLU.DevOps.CommandLine.Tests/BaseCommandMock.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/BaseCommandMock.cs
@@ -5,6 +5,7 @@ namespace NLU.DevOps.CommandLine.Tests
 {
     using System;
     using System.IO;
+    using System.Threading.Tasks;
     using Microsoft.Extensions.Logging;
     using Models;
     using Moq;
@@ -18,7 +19,7 @@ namespace NLU.DevOps.CommandLine.Tests
 
         public new ILogger Logger => base.Logger;
 
-        public override int Main()
+        public override Task<int> RunAsync()
         {
             throw new NotImplementedException();
         }

--- a/src/NLU.DevOps.CommandLine.Tests/Clean/CleanCommandTests.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/Clean/CleanCommandTests.cs
@@ -6,6 +6,7 @@ namespace NLU.DevOps.CommandLine.Tests.Clean
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Threading.Tasks;
     using CommandLine.Clean;
     using FluentAssertions;
     using global::CommandLine;
@@ -34,7 +35,7 @@ namespace NLU.DevOps.CommandLine.Tests.Clean
         }
 
         [Test]
-        public void WhenOptionToDeleteAppsettingsFile()
+        public async Task WhenOptionToDeleteAppsettingsFile()
         {
             using (TextWriter tw = new StreamWriter("appsettings.luis.json"))
             {
@@ -44,7 +45,7 @@ namespace NLU.DevOps.CommandLine.Tests.Clean
             File.Exists("appsettings.luis.json").Should().BeTrue();
             this.options.Add("-a");
             this.WhenParserIsRun();
-            this.commandUnderTest.Main();
+            await this.commandUnderTest.RunAsync().ConfigureAwait(false);
             File.Exists("appsettings.luis.json").Should().BeFalse();
         }
 

--- a/src/NLU.DevOps.CommandLine.Tests/Test/TestCommandTests.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/Test/TestCommandTests.cs
@@ -18,7 +18,7 @@ namespace NLU.DevOps.CommandLine.Tests.Test
     internal static class TestCommandTests
     {
         [Test]
-        public static void TestOutputTruncatesExistingFile()
+        public static async Task TestOutputTruncatesExistingFile()
         {
             var outputPath = Path.GetRandomFileName();
             File.WriteAllText(outputPath, string.Join(string.Empty, Enumerable.Repeat("!", 1000)));
@@ -30,7 +30,7 @@ namespace NLU.DevOps.CommandLine.Tests.Test
             };
 
             var testCommand = new TestCommandWithMockResult(testResult, options);
-            testCommand.Main();
+            await testCommand.RunAsync().ConfigureAwait(false);
 
             var content = File.ReadAllText(outputPath);
             var json = JToken.Parse(content);

--- a/src/NLU.DevOps.CommandLine.Tests/Train/TrainCommandTests.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/Train/TrainCommandTests.cs
@@ -6,6 +6,7 @@ namespace NLU.DevOps.CommandLine.Tests.Train
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Threading.Tasks;
     using CommandLine.Train;
     using FluentAssertions;
     using global::CommandLine;
@@ -35,7 +36,7 @@ namespace NLU.DevOps.CommandLine.Tests.Train
         public void WhenArgumentsDoNotIncludeUtterancesOrSettings()
         {
             this.WhenParserIsRun();
-            Action a = () => this.commandUnderTest.Main();
+            Func<Task> a = () => this.commandUnderTest.RunAsync();
             a.Should().Throw<InvalidOperationException>().WithMessage("Must specify either --utterances or --model-settings when using train.");
         }
 
@@ -45,18 +46,18 @@ namespace NLU.DevOps.CommandLine.Tests.Train
             this.options.Add("-u");
             this.options.Add("./bogusfolder/utterances.json");
             this.WhenParserIsRun();
-            Action a = () => this.commandUnderTest.Main();
+            Func<Task> a = () => this.commandUnderTest.RunAsync();
             a.Should().Throw<DirectoryNotFoundException>();
         }
 
         [Test]
-        public void SaveAppsettingsShouldCreateAFile()
+        public async Task SaveAppsettingsShouldCreateAFile()
         {
             this.options.Add("-u");
             this.options.Add("./testdata/utterances.json");
             this.options.Add("-a");
             this.WhenParserIsRun();
-            this.commandUnderTest.Main();
+            await this.commandUnderTest.RunAsync().ConfigureAwait(false);
             File.Exists("appsettings.luis.json").Should().BeTrue();
             File.Delete("appsettings.luis.json");
         }

--- a/src/NLU.DevOps.CommandLine/BaseCommand.cs
+++ b/src/NLU.DevOps.CommandLine/BaseCommand.cs
@@ -5,6 +5,7 @@ namespace NLU.DevOps.CommandLine
 {
     using System;
     using System.IO;
+    using System.Threading.Tasks;
     using Logging;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
@@ -40,7 +41,7 @@ namespace NLU.DevOps.CommandLine
 
         private Lazy<ILogger> LazyLogger { get; }
 
-        public abstract int Main();
+        public abstract Task<int> RunAsync();
 
         public void Dispose()
         {

--- a/src/NLU.DevOps.CommandLine/Clean/CleanCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Clean/CleanCommand.cs
@@ -14,13 +14,7 @@ namespace NLU.DevOps.CommandLine.Clean
         {
         }
 
-        public override int Main()
-        {
-            this.RunAsync().GetAwaiter().GetResult();
-            return 0;
-        }
-
-        private async Task RunAsync()
+        public override async Task<int> RunAsync()
         {
             this.Log("Cleaning NLU model...");
             await this.NLUTrainClient.CleanupAsync().ConfigureAwait(false);
@@ -29,6 +23,8 @@ namespace NLU.DevOps.CommandLine.Clean
             {
                 File.Delete($"appsettings.{this.Options.Service}.json");
             }
+
+            return 0;
         }
     }
 }

--- a/src/NLU.DevOps.CommandLine/Clean/CleanCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Clean/CleanCommand.cs
@@ -16,7 +16,7 @@ namespace NLU.DevOps.CommandLine.Clean
 
         public override int Main()
         {
-            this.RunAsync().Wait();
+            this.RunAsync().GetAwaiter().GetResult();
             return 0;
         }
 

--- a/src/NLU.DevOps.CommandLine/EnumerableExtensions.cs
+++ b/src/NLU.DevOps.CommandLine/EnumerableExtensions.cs
@@ -18,7 +18,7 @@ namespace NLU.DevOps.CommandLine
             }
 
             var indexedItems = items.Select((item, i) => new { Item = item, Index = i });
-            var results = new TResult[items.Count()];
+            var results = new List<TResult>();
             var tasks = new List<Task<Tuple<int, TResult>>>(degreeOfParallelism);
 
             async Task<Tuple<int, TResult>> selectWithIndexAsync(T item, int i)
@@ -37,6 +37,7 @@ namespace NLU.DevOps.CommandLine
                     results[/* (int) */ result.Item1] = /* (TResult) */ result.Item2;
                 }
 
+                results.Add(default);
                 tasks.Add(selectWithIndexAsync(indexedItem.Item, indexedItem.Index));
             }
 

--- a/src/NLU.DevOps.CommandLine/ICommand.cs
+++ b/src/NLU.DevOps.CommandLine/ICommand.cs
@@ -4,6 +4,7 @@
 namespace NLU.DevOps.CommandLine
 {
     using System;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Interface for commands.
@@ -14,6 +15,6 @@ namespace NLU.DevOps.CommandLine
         /// Command entry point.
         /// </summary>
         /// <returns>Exit code.</returns>
-        int Main();
+        Task<int> RunAsync();
     }
 }

--- a/src/NLU.DevOps.CommandLine/Test/TestCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Test/TestCommand.cs
@@ -25,7 +25,7 @@ namespace NLU.DevOps.CommandLine.Test
 
         public override int Main()
         {
-            this.RunAsync().Wait();
+            this.RunAsync().GetAwaiter().GetResult();
             return 0;
         }
 

--- a/src/NLU.DevOps.CommandLine/Test/TestCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Test/TestCommand.cs
@@ -23,27 +23,7 @@ namespace NLU.DevOps.CommandLine.Test
 
         private IDictionary<string, string> Transcriptions => this.LazyTranscriptions.Value;
 
-        public override int Main()
-        {
-            this.RunAsync().GetAwaiter().GetResult();
-            return 0;
-        }
-
-        protected override INLUTestClient CreateNLUTestClient()
-        {
-            return NLUClientFactory.CreateTestInstance(this.Options, this.Configuration, this.Options.SettingsPath);
-        }
-
-        private static void EnsureDirectory(string filePath)
-        {
-            var baseDirectory = Path.GetDirectoryName(filePath);
-            if (!string.IsNullOrEmpty(baseDirectory) && !Directory.Exists(baseDirectory))
-            {
-                Directory.CreateDirectory(baseDirectory);
-            }
-        }
-
-        private async Task RunAsync()
+        public override async Task<int> RunAsync()
         {
             this.Log("Running tests against NLU model...");
 
@@ -66,6 +46,22 @@ namespace NLU.DevOps.CommandLine.Test
             }
 
             this.SaveTranscriptions();
+
+            return 0;
+        }
+
+        protected override INLUTestClient CreateNLUTestClient()
+        {
+            return NLUClientFactory.CreateTestInstance(this.Options, this.Configuration, this.Options.SettingsPath);
+        }
+
+        private static void EnsureDirectory(string filePath)
+        {
+            var baseDirectory = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(baseDirectory) && !Directory.Exists(baseDirectory))
+            {
+                Directory.CreateDirectory(baseDirectory);
+            }
         }
 
         private Task<LabeledUtterance> TestAsync((JToken Query, string SpeechFile) utterance)

--- a/src/NLU.DevOps.CommandLine/Train/TrainCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Train/TrainCommand.cs
@@ -19,7 +19,7 @@ namespace NLU.DevOps.CommandLine.Train
 
         public override int Main()
         {
-            this.RunAsync().Wait();
+            this.RunAsync().GetAwaiter().GetResult();
             return 0;
         }
 

--- a/src/NLU.DevOps.CommandLine/Train/TrainCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Train/TrainCommand.cs
@@ -17,18 +17,7 @@ namespace NLU.DevOps.CommandLine.Train
         {
         }
 
-        public override int Main()
-        {
-            this.RunAsync().GetAwaiter().GetResult();
-            return 0;
-        }
-
-        protected override INLUTrainClient CreateNLUTrainClient()
-        {
-            return NLUClientFactory.CreateTrainInstance(this.Options, this.Configuration, this.Options.SettingsPath);
-        }
-
-        private async Task RunAsync()
+        public override async Task<int> RunAsync()
         {
             try
             {
@@ -51,6 +40,13 @@ namespace NLU.DevOps.CommandLine.Train
                     Write($"appsettings.{this.Options.Service}.json", this.NLUTrainClient);
                 }
             }
+
+            return 0;
+        }
+
+        protected override INLUTrainClient CreateNLUTrainClient()
+        {
+            return NLUClientFactory.CreateTrainInstance(this.Options, this.Configuration, this.Options.SettingsPath);
         }
 
         private class TrainLabeledUtterance : LabeledUtterance


### PR DESCRIPTION
Fixes issue where we parse JSON twice due to the lazily evaluated IEnumerable used for enumerating test cases. It remoes the need to use the Enumerable.Count<T>() extension method in the parallelized map operation to get test results.

This change also replaces occurences of Task.Wait() with Task.GetAwaiter().GetResult() to improve the stack trace for better error reporting.

Fixes #309
