### PR TITLE
Adds option to set absolute thresholds

### DIFF
--- a/src/NLU.DevOps.ModelPerformance.Tests/NLUAccuracyTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/NLUAccuracyTests.cs
@@ -3,6 +3,7 @@
 
 namespace NLU.DevOps.ModelPerformance.Tests
 {
+    using System.Collections.Generic;
     using FluentAssertions;
     using NUnit.Framework;
 
@@ -63,6 +64,72 @@ namespace NLU.DevOps.ModelPerformance.Tests
         {
             var matrix = new ConfusionMatrix(1, 0, 1, 0);
             matrix.GetMetric(null).Should().Be(matrix.F1());
+        }
+
+        [Test]
+        public static void CheckThresholdPass()
+        {
+            var threshold = new NLUThreshold
+            {
+                Type = "intent",
+            };
+
+            var current = GetStatistics(new ConfusionMatrix(1, 0, 1, 0));
+            var baseline = GetStatistics(new ConfusionMatrix(0, 0, 2, 0));
+            NLUAccuracy.CheckThreshold(current, baseline, threshold).Should().BeTrue();
+        }
+
+        [Test]
+        public static void CheckThresholdFail()
+        {
+            var threshold = new NLUThreshold
+            {
+                Type = "intent",
+            };
+
+            var current = GetStatistics(new ConfusionMatrix(0, 0, 2, 0));
+            var baseline = GetStatistics(new ConfusionMatrix(1, 0, 1, 0));
+            NLUAccuracy.CheckThreshold(current, baseline, threshold).Should().BeFalse();
+        }
+
+        [Test]
+        public static void CheckThresholdAbsolutePass()
+        {
+            var threshold = new NLUThreshold
+            {
+                Type = "intent",
+                Threshold = 0.5,
+                Comparison = NLUThresholdKind.Absolute,
+            };
+
+            var current = GetStatistics(new ConfusionMatrix(1, 0, 0, 0));
+            NLUAccuracy.CheckThreshold(current, null, threshold).Should().BeTrue();
+        }
+
+        [Test]
+        public static void CheckThresholdAbsoluteFail()
+        {
+            var threshold = new NLUThreshold
+            {
+                Type = "intent",
+                Threshold = 0.5,
+                Comparison = NLUThresholdKind.Absolute,
+            };
+
+            var current = GetStatistics(new ConfusionMatrix(0, 0, 1, 0));
+            NLUAccuracy.CheckThreshold(current, null, threshold).Should().BeFalse();
+        }
+
+        private static NLUStatistics GetStatistics(ConfusionMatrix intent)
+        {
+            return new NLUStatistics(
+                ConfusionMatrix.Default,
+                intent,
+                ConfusionMatrix.Default,
+                ConfusionMatrix.Default,
+                new Dictionary<string, ConfusionMatrix>(),
+                new Dictionary<string, ConfusionMatrix>(),
+                new Dictionary<string, ConfusionMatrix>());
         }
     }
 }

--- a/src/NLU.DevOps.ModelPerformance/NLUAccuracy.cs
+++ b/src/NLU.DevOps.ModelPerformance/NLUAccuracy.cs
@@ -55,8 +55,13 @@ namespace NLU.DevOps.ModelPerformance
                 return null;
             }
 
-            var baselineMatrix = getResults(baselineResults) ?? ConfusionMatrix.Default;
             var currentMatrix = getResults(currentResults) ?? ConfusionMatrix.Default;
+            if (threshold.Comparison == NLUThresholdKind.Absolute)
+            {
+                return currentMatrix.GetMetric(threshold.Metric) >= threshold.Threshold;
+            }
+
+            var baselineMatrix = getResults(baselineResults) ?? ConfusionMatrix.Default;
             return baselineMatrix.GetMetric(threshold.Metric) - currentMatrix.GetMetric(threshold.Metric) <= threshold.Threshold;
         }
 

--- a/src/NLU.DevOps.ModelPerformance/NLUThreshold.cs
+++ b/src/NLU.DevOps.ModelPerformance/NLUThreshold.cs
@@ -27,5 +27,10 @@ namespace NLU.DevOps.ModelPerformance
         /// Gets or sets the comparison metric.
         /// </summary>
         public string Metric { get; set; }
+
+        /// <summary>
+        /// Gets or sets the comparison type, relative or absolute.
+        /// </summary>
+        public NLUThresholdKind Comparison { get; set; }
     }
 }

--- a/src/NLU.DevOps.ModelPerformance/NLUThresholdKind.cs
+++ b/src/NLU.DevOps.ModelPerformance/NLUThresholdKind.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.ModelPerformance
+{
+    /// <summary>
+    /// Comparison types, either relative or absolute.
+    /// </summary>
+    public enum NLUThresholdKind
+    {
+        /// <summary>
+        /// Relative threshold.
+        /// </summary>
+        Relative = 0,
+
+        /// <summary>
+        /// Absolute threshold.
+        /// </summary>
+        Absolute,
+    }
+}


### PR DESCRIPTION
For the performance regression functionality in the `compare` command, this change adds the option to set absolute thresholds for F<sub>1</sub> scores. For example, a user may want to ensure that the F<sub>1</sub> score for a given intent never falls below 0.5. To define this, with this change, they could add a threshold as follows:
```yaml
thresholds:
- type: intent
  group: PlayMusic
  comparison: absolute
  threshold: 0.5
```

Fixes #312