### PR TITLE
Refactors utterance and entity types to interfaces

### DIFF
--- a/src/CommonNuget.props
+++ b/src/CommonNuget.props
@@ -8,6 +8,6 @@
     <PackageProjectUrl>https://github.com/Microsoft/NLU.DevOps</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Microsoft/NLU.DevOps.git</RepositoryUrl>
     <Copyright>© Microsoft Corporation.</Copyright>
-    <Version>0.7.5</Version>
+    <Version>0.8.0</Version>
   </PropertyGroup>
 </Project>

--- a/src/NLU.DevOps.CommandLine.Tests/MockNLUTrainClient.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/MockNLUTrainClient.cs
@@ -15,7 +15,7 @@ namespace NLU.DevOps.CommandLine.Tests
         public Task CleanupAsync(CancellationToken cancellationToken) =>
             Task.FromResult(0);
 
-        public Task TrainAsync(IEnumerable<LabeledUtterance> utterances, CancellationToken cancellationToken) =>
+        public Task TrainAsync(IEnumerable<ILabeledUtterance> utterances, CancellationToken cancellationToken) =>
             Task.FromResult(0);
 
         public void Dispose()

--- a/src/NLU.DevOps.CommandLine.Tests/Test/TestCommandTests.cs
+++ b/src/NLU.DevOps.CommandLine.Tests/Test/TestCommandTests.cs
@@ -7,6 +7,7 @@ namespace NLU.DevOps.CommandLine.Tests.Test
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Core;
     using FluentAssertions;
     using Models;
     using Moq;
@@ -39,13 +40,13 @@ namespace NLU.DevOps.CommandLine.Tests.Test
 
         private class TestCommandWithMockResult : TestCommand
         {
-            public TestCommandWithMockResult(LabeledUtterance testResult, TestOptions options)
+            public TestCommandWithMockResult(ILabeledUtterance testResult, TestOptions options)
                 : base(options)
             {
                 this.TestResult = testResult;
             }
 
-            private LabeledUtterance TestResult { get; }
+            private ILabeledUtterance TestResult { get; }
 
             protected override INLUTestClient CreateNLUTestClient()
             {

--- a/src/NLU.DevOps.CommandLine/Test/TestCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Test/TestCommand.cs
@@ -64,14 +64,14 @@ namespace NLU.DevOps.CommandLine.Test
             }
         }
 
-        private Task<LabeledUtterance> TestAsync((JToken Query, string SpeechFile) utterance)
+        private Task<ILabeledUtterance> TestAsync((JToken Query, string SpeechFile) utterance)
         {
             return utterance.SpeechFile != null
                 ? this.TestSpeechAsync(utterance)
                 : this.NLUTestClient.TestAsync(utterance.Query);
         }
 
-        private async Task<LabeledUtterance> TestSpeechAsync((JToken Query, string SpeechFile) utterance)
+        private async Task<ILabeledUtterance> TestSpeechAsync((JToken Query, string SpeechFile) utterance)
         {
             var text = default(string);
             if (this.Transcriptions?.TryGetValue(utterance.SpeechFile, out text) ?? false)

--- a/src/NLU.DevOps.CommandLine/Train/TrainCommand.cs
+++ b/src/NLU.DevOps.CommandLine/Train/TrainCommand.cs
@@ -6,6 +6,7 @@ namespace NLU.DevOps.CommandLine.Train
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using Core;
     using Models;
     using Newtonsoft.Json;
     using static Serializer;

--- a/src/NLU.DevOps.Core/DefaultNLUTestClient.cs
+++ b/src/NLU.DevOps.Core/DefaultNLUTestClient.cs
@@ -14,7 +14,7 @@ namespace NLU.DevOps.Core
     public abstract class DefaultNLUTestClient : NLUTestClientBase<DefaultQuery>
     {
         /// <inheritdoc />
-        protected sealed override Task<LabeledUtterance> TestAsync(DefaultQuery query, CancellationToken cancellationToken)
+        protected sealed override Task<ILabeledUtterance> TestAsync(DefaultQuery query, CancellationToken cancellationToken)
         {
             return this.TestAsync(query.Text, cancellationToken);
         }
@@ -25,10 +25,10 @@ namespace NLU.DevOps.Core
         /// <returns>Task to await the resulting labeled utterance.</returns>
         /// <param name="utterance">Unlabeled utterance to test on.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        protected abstract Task<LabeledUtterance> TestAsync(string utterance, CancellationToken cancellationToken);
+        protected abstract Task<ILabeledUtterance> TestAsync(string utterance, CancellationToken cancellationToken);
 
         /// <inheritdoc />
-        protected sealed override Task<LabeledUtterance> TestSpeechAsync(string speechFile, DefaultQuery query, CancellationToken cancellationToken)
+        protected sealed override Task<ILabeledUtterance> TestSpeechAsync(string speechFile, DefaultQuery query, CancellationToken cancellationToken)
         {
             return this.TestSpeechAsync(speechFile, cancellationToken);
         }
@@ -39,6 +39,6 @@ namespace NLU.DevOps.Core
         /// <returns>Task to await the resulting labeled utterance.</returns>
         /// <param name="speechFile">Speech files to test on.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        protected abstract Task<LabeledUtterance> TestSpeechAsync(string speechFile, CancellationToken cancellationToken);
+        protected abstract Task<ILabeledUtterance> TestSpeechAsync(string speechFile, CancellationToken cancellationToken);
     }
 }

--- a/src/NLU.DevOps.Core/Entity.cs
+++ b/src/NLU.DevOps.Core/Entity.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace NLU.DevOps.Models
+namespace NLU.DevOps.Core
 {
+    using Models;
     using Newtonsoft.Json.Linq;
 
     /// <summary>
     /// Entity appearing in utterance.
     /// </summary>
-    public class Entity
+    public class Entity : IEntity
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Entity"/> class.

--- a/src/NLU.DevOps.Core/EntityExtensions.cs
+++ b/src/NLU.DevOps.Core/EntityExtensions.cs
@@ -17,7 +17,7 @@ namespace NLU.DevOps.Models
         /// <returns>The start <code>char</code> index.</returns>
         /// <param name="entity">Entity.</param>
         /// <param name="text">Text.</param>
-        public static int StartCharIndexInText(this Entity entity, string text)
+        public static int StartCharIndexInText(this IEntity entity, string text)
         {
             var match = Regex.Match(text, entity.MatchText);
             for (var i = 0; i < entity.MatchIndex; ++i)

--- a/src/NLU.DevOps.Core/JsonLabeledUtterance.cs
+++ b/src/NLU.DevOps.Core/JsonLabeledUtterance.cs
@@ -18,7 +18,7 @@ namespace NLU.DevOps.Core
         /// <param name="text">Text of the utterance.</param>
         /// <param name="intent">Intent of the utterance.</param>
         /// <param name="entities">Entities referenced in the utterance.</param>
-        public JsonLabeledUtterance(string text, string intent, IReadOnlyList<Entity> entities)
+        public JsonLabeledUtterance(string text, string intent, IReadOnlyList<IEntity> entities)
             : base(text, intent, entities)
         {
         }

--- a/src/NLU.DevOps.Core/LabeledUtterance.cs
+++ b/src/NLU.DevOps.Core/LabeledUtterance.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace NLU.DevOps.Models
+namespace NLU.DevOps.Core
 {
     using System.Collections.Generic;
+    using Models;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// Labeled utterance.
     /// </summary>
-    public class LabeledUtterance
+    public class LabeledUtterance : ILabeledUtterance
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LabeledUtterance"/> class.
@@ -16,7 +18,21 @@ namespace NLU.DevOps.Models
         /// <param name="text">Text of the utterance.</param>
         /// <param name="intent">Intent of the utterance.</param>
         /// <param name="entities">Entities referenced in the utterance.</param>
-        public LabeledUtterance(string text, string intent, IReadOnlyList<Entity> entities)
+        public LabeledUtterance(string text, string intent, IReadOnlyList<IEntity> entities)
+        {
+            this.Text = text;
+            this.Intent = intent;
+            this.Entities = entities;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LabeledUtterance"/> class.
+        /// </summary>
+        /// <param name="text">Text of the utterance.</param>
+        /// <param name="intent">Intent of the utterance.</param>
+        /// <param name="entities">Entities referenced in the utterance.</param>
+        [JsonConstructor]
+        private LabeledUtterance(string text, string intent, IReadOnlyList<Entity> entities)
         {
             this.Text = text;
             this.Intent = intent;
@@ -36,6 +52,6 @@ namespace NLU.DevOps.Models
         /// <summary>
         /// Gets the entities referenced in the utterance.
         /// </summary>
-        public IReadOnlyList<Entity> Entities { get; }
+        public IReadOnlyList<IEntity> Entities { get; }
     }
 }

--- a/src/NLU.DevOps.Core/LabeledUtterancePropertyExtensions.cs
+++ b/src/NLU.DevOps.Core/LabeledUtterancePropertyExtensions.cs
@@ -22,7 +22,7 @@ namespace NLU.DevOps.Core
         /// <param name="instance">Labeled utterance instance.</param>
         /// <param name="score">Confidence score.</param>
         /// <returns>Labeled utterance with intent confidence score.</returns>
-        public static LabeledUtterance WithScore(this LabeledUtterance instance, double? score)
+        public static ILabeledUtterance WithScore(this ILabeledUtterance instance, double? score)
         {
             return instance.WithProperty(ScorePropertyName, score, ToJsonLabeledUtterance);
         }
@@ -33,7 +33,7 @@ namespace NLU.DevOps.Core
         /// <param name="instance">Labeled utterance instance.</param>
         /// <param name="textScore">Confidence score.</param>
         /// <returns>Labeled utterance with transcription confidence score.</returns>
-        public static LabeledUtterance WithTextScore(this LabeledUtterance instance, double? textScore)
+        public static ILabeledUtterance WithTextScore(this ILabeledUtterance instance, double? textScore)
         {
             return instance.WithProperty(TextScorePropertyName, textScore, ToJsonLabeledUtterance);
         }
@@ -44,7 +44,7 @@ namespace NLU.DevOps.Core
         /// <param name="instance">Labeled utterance instance.</param>
         /// <param name="timestamp">Timestamp.</param>
         /// <returns>Labeled utterance with timestamp.</returns>
-        public static LabeledUtterance WithTimestamp(this LabeledUtterance instance, DateTimeOffset? timestamp)
+        public static ILabeledUtterance WithTimestamp(this ILabeledUtterance instance, DateTimeOffset? timestamp)
         {
             return instance.WithProperty(TimestampPropertyName, timestamp, ToJsonLabeledUtterance);
         }
@@ -56,7 +56,7 @@ namespace NLU.DevOps.Core
         /// <param name="propertyName">Property name.</param>
         /// <param name="propertyValue">Property value.</param>
         /// <returns>Labeled utterance with additional property.</returns>
-        public static LabeledUtterance WithProperty(this LabeledUtterance instance, string propertyName, object propertyValue)
+        public static ILabeledUtterance WithProperty(this ILabeledUtterance instance, string propertyName, object propertyValue)
         {
             return instance.WithProperty(propertyName, propertyValue, ToJsonLabeledUtterance);
         }
@@ -67,7 +67,7 @@ namespace NLU.DevOps.Core
         /// <param name="instance">Entity instance.</param>
         /// <param name="score">Confidence score.</param>
         /// <returns>Entity with confidence score.</returns>
-        public static Entity WithScore(this Entity instance, double? score)
+        public static IEntity WithScore(this IEntity instance, double? score)
         {
             return instance.WithProperty(ScorePropertyName, score, ToJsonEntity);
         }
@@ -79,7 +79,7 @@ namespace NLU.DevOps.Core
         /// <returns>
         /// Intent confidence score, or <code>null</code> if property is not set.
         /// </returns>
-        public static double? GetScore(this LabeledUtterance instance)
+        public static double? GetScore(this ILabeledUtterance instance)
         {
             return instance.GetNumericProperty(ScorePropertyName);
         }
@@ -91,7 +91,7 @@ namespace NLU.DevOps.Core
         /// <returns>
         /// Transcription confidence score, or <code>null</code> if property is not set.
         /// </returns>
-        public static double? GetTextScore(this LabeledUtterance instance)
+        public static double? GetTextScore(this ILabeledUtterance instance)
         {
             return instance.GetNumericProperty(TextScorePropertyName);
         }
@@ -103,7 +103,7 @@ namespace NLU.DevOps.Core
         /// <returns>
         /// Timestamp, or <code>null</code> if property is not set.
         /// </returns>
-        public static DateTimeOffset? GetTimestamp(this LabeledUtterance instance)
+        public static DateTimeOffset? GetTimestamp(this ILabeledUtterance instance)
         {
             return instance.GetPropertyCore<DateTimeOffset?>(TimestampPropertyName);
         }
@@ -117,7 +117,7 @@ namespace NLU.DevOps.Core
         /// <returns>
         /// Property value, or default if property is not set.
         /// </returns>
-        public static T GetProperty<T>(this LabeledUtterance instance, string propertyName)
+        public static T GetProperty<T>(this ILabeledUtterance instance, string propertyName)
         {
             return instance.GetPropertyCore<T>(propertyName);
         }
@@ -129,7 +129,7 @@ namespace NLU.DevOps.Core
         /// <returns>
         /// Entity confidence score, or <code>null</code> if property is not set.
         /// </returns>
-        public static double? GetScore(this Entity instance)
+        public static double? GetScore(this IEntity instance)
         {
             return instance.GetPropertyCore<double?>(ScorePropertyName);
         }
@@ -157,14 +157,14 @@ namespace NLU.DevOps.Core
             return extension;
         }
 
-        private static JsonLabeledUtterance ToJsonLabeledUtterance(this LabeledUtterance utterance)
+        private static JsonLabeledUtterance ToJsonLabeledUtterance(this ILabeledUtterance utterance)
         {
             return utterance is JsonLabeledUtterance jsonUtterance
                 ? jsonUtterance
                 : new JsonLabeledUtterance(utterance.Text, utterance.Intent, utterance.Entities);
         }
 
-        private static JsonEntity ToJsonEntity(this Entity entity)
+        private static JsonEntity ToJsonEntity(this IEntity entity)
         {
             return entity is JsonEntity jsonEntity
                 ? jsonEntity

--- a/src/NLU.DevOps.Core/NLU.DevOps.Core.csproj
+++ b/src/NLU.DevOps.Core/NLU.DevOps.Core.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CodeAnalysis.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>0.7.0</AssemblyVersion>
+    <AssemblyVersion>0.8.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">

--- a/src/NLU.DevOps.Core/NLUTestClientBase.cs
+++ b/src/NLU.DevOps.Core/NLUTestClientBase.cs
@@ -16,7 +16,7 @@ namespace NLU.DevOps.Core
     public abstract class NLUTestClientBase<TQuery> : INLUTestClient
     {
         /// <inheritdoc />
-        public Task<LabeledUtterance> TestAsync(JToken query, CancellationToken cancellationToken)
+        public Task<ILabeledUtterance> TestAsync(JToken query, CancellationToken cancellationToken)
         {
             if (query == null)
             {
@@ -28,7 +28,7 @@ namespace NLU.DevOps.Core
         }
 
         /// <inheritdoc />
-        public Task<LabeledUtterance> TestSpeechAsync(string speechFile, JToken query, CancellationToken cancellationToken)
+        public Task<ILabeledUtterance> TestSpeechAsync(string speechFile, JToken query, CancellationToken cancellationToken)
         {
             if (speechFile == null)
             {
@@ -57,7 +57,7 @@ namespace NLU.DevOps.Core
         /// <returns>Task to await the resulting labeled utterance.</returns>
         /// <param name="query">Query to test.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        protected abstract Task<LabeledUtterance> TestAsync(TQuery query, CancellationToken cancellationToken);
+        protected abstract Task<ILabeledUtterance> TestAsync(TQuery query, CancellationToken cancellationToken);
 
         /// <summary>
         /// Tests the NLU model using speech.
@@ -66,7 +66,7 @@ namespace NLU.DevOps.Core
         /// <param name="speechFile">Speech file to test on.</param>
         /// <param name="query">Query to test.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        protected abstract Task<LabeledUtterance> TestSpeechAsync(string speechFile, TQuery query, CancellationToken cancellationToken);
+        protected abstract Task<ILabeledUtterance> TestSpeechAsync(string speechFile, TQuery query, CancellationToken cancellationToken);
 
         /// <summary>
         /// Disposes the NLU client.

--- a/src/NLU.DevOps.Dialogflow/DialogflowNLUTestClient.cs
+++ b/src/NLU.DevOps.Dialogflow/DialogflowNLUTestClient.cs
@@ -55,7 +55,7 @@ namespace NLU.DevOps.Dialogflow
 
         private string SessionId => this.GetConfigurationValue(DialogflowSessionIdConfigurationKey, true);
 
-        protected override async Task<LabeledUtterance> TestAsync(string utterance, CancellationToken cancellationToken)
+        protected override async Task<ILabeledUtterance> TestAsync(string utterance, CancellationToken cancellationToken)
         {
             var sessionId = this.SessionId ?? Guid.NewGuid().ToString();
             var sessionName = new SessionName(this.ProjectId, sessionId);
@@ -85,7 +85,7 @@ namespace NLU.DevOps.Dialogflow
                 .ConfigureAwait(false);
         }
 
-        protected override async Task<LabeledUtterance> TestSpeechAsync(string speechFile, CancellationToken cancellationToken)
+        protected override async Task<ILabeledUtterance> TestSpeechAsync(string speechFile, CancellationToken cancellationToken)
         {
             var sessionId = this.SessionId ?? Guid.NewGuid().ToString();
             var sessionName = new SessionName(this.ProjectId, sessionId);

--- a/src/NLU.DevOps.Lex.Tests/LexNLUClientExtensions.cs
+++ b/src/NLU.DevOps.Lex.Tests/LexNLUClientExtensions.cs
@@ -10,7 +10,7 @@ namespace NLU.DevOps.Lex.Tests
 
     internal static class LexNLUClientExtensions
     {
-        public static Task<LabeledUtterance> TestAsync(this LexNLUTestClient client, string utterance)
+        public static Task<ILabeledUtterance> TestAsync(this LexNLUTestClient client, string utterance)
         {
             return client.TestAsync(new JObject { { "text", utterance } });
         }

--- a/src/NLU.DevOps.Lex.Tests/LexNLUTrainClientTests.cs
+++ b/src/NLU.DevOps.Lex.Tests/LexNLUTrainClientTests.cs
@@ -12,6 +12,7 @@ namespace NLU.DevOps.Lex.Tests
     using System.Threading.Tasks;
     using Amazon.LexModelBuildingService;
     using Amazon.LexModelBuildingService.Model;
+    using Core;
     using FluentAssertions;
     using Models;
     using Moq;

--- a/src/NLU.DevOps.Lex/LexNLUTestClient.cs
+++ b/src/NLU.DevOps.Lex/LexNLUTestClient.cs
@@ -66,7 +66,7 @@ namespace NLU.DevOps.Lex
         private ILexTestClient LexClient { get; }
 
         /// <inheritdoc />
-        protected override async Task<LabeledUtterance> TestAsync(string utterance, CancellationToken cancellationToken)
+        protected override async Task<ILabeledUtterance> TestAsync(string utterance, CancellationToken cancellationToken)
         {
             if (utterance == null)
             {
@@ -92,7 +92,7 @@ namespace NLU.DevOps.Lex
         }
 
         /// <inheritdoc />
-        protected override async Task<LabeledUtterance> TestSpeechAsync(string speechFile, CancellationToken cancellationToken)
+        protected override async Task<ILabeledUtterance> TestSpeechAsync(string speechFile, CancellationToken cancellationToken)
         {
             if (speechFile == null)
             {

--- a/src/NLU.DevOps.Lex/LexNLUTrainClient.cs
+++ b/src/NLU.DevOps.Lex/LexNLUTrainClient.cs
@@ -86,7 +86,7 @@ namespace NLU.DevOps.Lex
         private ILexTrainClient LexClient { get; }
 
         /// <inheritdoc />
-        public async Task TrainAsync(IEnumerable<LabeledUtterance> utterances, CancellationToken cancellationToken)
+        public async Task TrainAsync(IEnumerable<ILabeledUtterance> utterances, CancellationToken cancellationToken)
         {
             // Validate arguments
             if (utterances == null)
@@ -138,7 +138,7 @@ namespace NLU.DevOps.Lex
             this.LexClient.Dispose();
         }
 
-        private static JToken CreateIntent(string intent, IEnumerable<LabeledUtterance> utterances)
+        private static JToken CreateIntent(string intent, IEnumerable<ILabeledUtterance> utterances)
         {
             // Create a new intent with the given name
             var intentJson = ImportBotTemplates.IntentJson;
@@ -149,7 +149,7 @@ namespace NLU.DevOps.Lex
             // Currently, the algorithm only adds slots that
             // exist in the training set for the given intent.
             var slots = utterances
-                .SelectMany(utterance => utterance.Entities ?? Array.Empty<Entity>())
+                .SelectMany(utterance => utterance.Entities ?? Array.Empty<IEntity>())
                 .Select(entity => entity.EntityType)
                 .Distinct()
                 .Select(slot =>
@@ -173,7 +173,7 @@ namespace NLU.DevOps.Lex
             return intentJson;
         }
 
-        private static string CreateSampleUtterance(LabeledUtterance utterance)
+        private static string CreateSampleUtterance(ILabeledUtterance utterance)
         {
             var text = utterance.Text;
             if (utterance.Entities != null)
@@ -261,7 +261,7 @@ namespace NLU.DevOps.Lex
             return this.LexClient.PutBotAsync(putBotRequest, cancellationToken);
         }
 
-        private JToken CreateImportJson(IEnumerable<LabeledUtterance> utterances)
+        private JToken CreateImportJson(IEnumerable<ILabeledUtterance> utterances)
         {
             // Add name to imports JSON template
             var importJson = ImportBotTemplates.ImportJson;

--- a/src/NLU.DevOps.Luis.Shared/LabeledUtteranceExtensions.cs
+++ b/src/NLU.DevOps.Luis.Shared/LabeledUtteranceExtensions.cs
@@ -10,9 +10,9 @@ namespace NLU.DevOps.Luis
 
     internal static class LabeledUtteranceExtensions
     {
-        public static JSONUtterance ToJSONUtterance(this Models.LabeledUtterance utterance, LuisApp luisApp)
+        public static JSONUtterance ToJSONUtterance(this ILabeledUtterance utterance, LuisApp luisApp)
         {
-            JSONEntity toJSONEntity(Entity entity)
+            JSONEntity toJSONEntity(IEntity entity)
             {
                 var startPos = entity.StartCharIndexInText(utterance.Text);
                 var endPos = startPos + entity.MatchText.Length - 1;

--- a/src/NLU.DevOps.Luis.Shared/LuisNLUTrainClient.cs
+++ b/src/NLU.DevOps.Luis.Shared/LuisNLUTrainClient.cs
@@ -64,7 +64,7 @@ namespace NLU.DevOps.Luis
 
         /// <inheritdoc />
         public async Task TrainAsync(
-            IEnumerable<Models.LabeledUtterance> utterances,
+            IEnumerable<ILabeledUtterance> utterances,
             CancellationToken cancellationToken)
         {
             try
@@ -165,7 +165,7 @@ namespace NLU.DevOps.Luis
                 && statusCode != HttpStatusCode.NotImplemented);
         }
 
-        private LuisApp CreateLuisApp(IEnumerable<Models.LabeledUtterance> utterances)
+        private LuisApp CreateLuisApp(IEnumerable<ILabeledUtterance> utterances)
         {
             var luisApp = this.CreateLuisAppTemplate();
 

--- a/src/NLU.DevOps.Luis.Tests.Shared/LuisNLUTestClientExtensions.cs
+++ b/src/NLU.DevOps.Luis.Tests.Shared/LuisNLUTestClientExtensions.cs
@@ -9,7 +9,7 @@ namespace NLU.DevOps.Luis.Tests
 
     internal static class LuisNLUTestClientExtensions
     {
-        public static Task<LabeledUtterance> TestAsync(this LuisNLUTestClient service, string utterance)
+        public static Task<ILabeledUtterance> TestAsync(this LuisNLUTestClient service, string utterance)
         {
             return service.TestAsync(new JObject { { "text", utterance } });
         }

--- a/src/NLU.DevOps.Luis.Tests.Shared/LuisNLUTrainClientTests.cs
+++ b/src/NLU.DevOps.Luis.Tests.Shared/LuisNLUTrainClientTests.cs
@@ -9,6 +9,7 @@ namespace NLU.DevOps.Luis.Tests
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Core;
     using FluentAssertions;
     using Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring.Models;
     using Microsoft.Extensions.Configuration;
@@ -39,7 +40,7 @@ namespace NLU.DevOps.Luis.Tests
             using (var luis = new LuisNLUTrainClientBuilder().Build())
             {
                 Func<Task> nullUtterances = () => luis.TrainAsync(null);
-                Func<Task> nullUtterance = () => luis.TrainAsync(new Models.LabeledUtterance[] { null });
+                Func<Task> nullUtterance = () => luis.TrainAsync(new Core.LabeledUtterance[] { null });
                 nullUtterances.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("utterances");
                 nullUtterance.Should().Throw<ArgumentException>().And.ParamName.Should().Be("utterances");
             }
@@ -52,7 +53,7 @@ namespace NLU.DevOps.Luis.Tests
             builder.AppVersion = Guid.NewGuid().ToString();
             using (var luis = builder.Build())
             {
-                var utterances = Array.Empty<Models.LabeledUtterance>();
+                var utterances = Array.Empty<ILabeledUtterance>();
                 await luis.TrainAsync(utterances).ConfigureAwait(false);
 
                 // Assert correct import request
@@ -85,8 +86,8 @@ namespace NLU.DevOps.Luis.Tests
             {
                 var utterances = new[]
                 {
-                    new Models.LabeledUtterance("Book me a flight.", "BookFlight", Array.Empty<Entity>()),
-                    new Models.LabeledUtterance("Cancel my flight.", "CancelFlight", Array.Empty<Entity>())
+                    new Core.LabeledUtterance("Book me a flight.", "BookFlight", Array.Empty<Entity>()),
+                    new Core.LabeledUtterance("Cancel my flight.", "CancelFlight", Array.Empty<Entity>())
                 };
 
                 await luis.TrainAsync(utterances).ConfigureAwait(false);
@@ -125,11 +126,11 @@ namespace NLU.DevOps.Luis.Tests
             {
                 var utterances = new[]
                 {
-                    new Models.LabeledUtterance(
+                    new Core.LabeledUtterance(
                         "Book me a flight.",
                         "BookFlight",
                         new[] { new Entity("Name", null, "me", 0) }),
-                    new Models.LabeledUtterance(
+                    new Core.LabeledUtterance(
                         "Cancel my flight.",
                         "CancelFlight",
                         new[] { new Entity("Subject", null, "flight", 0) })
@@ -225,7 +226,7 @@ namespace NLU.DevOps.Luis.Tests
 
             using (var luis = builder.Build())
             {
-                await luis.TrainAsync(Array.Empty<Models.LabeledUtterance>()).ConfigureAwait(false);
+                await luis.TrainAsync(Array.Empty<ILabeledUtterance>()).ConfigureAwait(false);
 
                 // Ensure correct number of training status requests are made.
                 builder.MockLuisTrainClient.Invocations.Where(request => request.Method.Name == nameof(ILuisTrainClient.GetTrainingStatusAsync))
@@ -260,7 +261,7 @@ namespace NLU.DevOps.Luis.Tests
 
             using (var luis = builder.Build())
             {
-                Func<Task> trainAsync = () => luis.TrainAsync(Array.Empty<Models.LabeledUtterance>());
+                Func<Task> trainAsync = () => luis.TrainAsync(Array.Empty<ILabeledUtterance>());
                 trainAsync.Should().Throw<InvalidOperationException>().And.Message.Should().Contain(failureReason);
             }
         }
@@ -279,7 +280,7 @@ namespace NLU.DevOps.Luis.Tests
 
             using (var luis = builder.Build())
             {
-                await luis.TrainAsync(Array.Empty<Models.LabeledUtterance>()).ConfigureAwait(false);
+                await luis.TrainAsync(Array.Empty<ILabeledUtterance>()).ConfigureAwait(false);
                 luis.LuisAppId.Should().Be(appId);
             }
         }
@@ -309,7 +310,7 @@ namespace NLU.DevOps.Luis.Tests
             builder.LuisTemplate = appTemplate;
             using (var luis = builder.Build())
             {
-                var utterance = new Models.LabeledUtterance(null, intentName, null);
+                var utterance = new Core.LabeledUtterance(null, intentName, null);
                 await luis.TrainAsync(new[] { utterance }).ConfigureAwait(false);
 
                 // Ensure LUIS app intent still has role
@@ -344,7 +345,7 @@ namespace NLU.DevOps.Luis.Tests
             {
                 var entity1 = new Entity("number", null, text, 0);
                 var entity2 = new Entity("count", null, text, 0);
-                var utterance = new Models.LabeledUtterance(text, string.Empty, new[] { entity1, entity2 });
+                var utterance = new Core.LabeledUtterance(text, string.Empty, new[] { entity1, entity2 });
                 await luis.TrainAsync(new[] { utterance }).ConfigureAwait(false);
 
                 // Ensure LUIS app intent still has role

--- a/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.Luis/LuisNLUTestClient.cs
@@ -38,7 +38,7 @@ namespace NLU.DevOps.Luis
         private ILuisTestClient LuisClient { get; }
 
         /// <inheritdoc />
-        protected override async Task<LabeledUtterance> TestAsync(
+        protected override async Task<ILabeledUtterance> TestAsync(
             string utterance,
             CancellationToken cancellationToken)
         {
@@ -63,7 +63,7 @@ namespace NLU.DevOps.Luis
         }
 
         /// <inheritdoc />
-        protected override async Task<LabeledUtterance> TestSpeechAsync(
+        protected override async Task<ILabeledUtterance> TestSpeechAsync(
             string speechFile,
             CancellationToken cancellationToken)
         {
@@ -77,14 +77,14 @@ namespace NLU.DevOps.Luis
             this.LuisClient.Dispose();
         }
 
-        private static LabeledUtterance LuisResultToLabeledUtterance(SpeechLuisResult speechLuisResult)
+        private static ILabeledUtterance LuisResultToLabeledUtterance(SpeechLuisResult speechLuisResult)
         {
             if (speechLuisResult == null)
             {
                 return new LabeledUtterance(null, null, null);
             }
 
-            Entity getEntity(EntityModel entity)
+            IEntity getEntity(EntityModel entity)
             {
                 var entityType = entity.Type;
                 if (entity.AdditionalProperties != null &&

--- a/src/NLU.DevOps.LuisV3/LuisNLUTestClient.cs
+++ b/src/NLU.DevOps.LuisV3/LuisNLUTestClient.cs
@@ -37,7 +37,7 @@ namespace NLU.DevOps.Luis
         private ILuisTestClient LuisClient { get; }
 
         /// <inheritdoc />
-        public async Task<LabeledUtterance> TestAsync(
+        public async Task<ILabeledUtterance> TestAsync(
             JToken query,
             CancellationToken cancellationToken)
         {
@@ -69,7 +69,7 @@ namespace NLU.DevOps.Luis
         }
 
         /// <inheritdoc />
-        public async Task<LabeledUtterance> TestSpeechAsync(
+        public async Task<ILabeledUtterance> TestSpeechAsync(
             string speechFile,
             JToken query,
             CancellationToken cancellationToken)
@@ -95,14 +95,14 @@ namespace NLU.DevOps.Luis
             this.LuisClient.Dispose();
         }
 
-        private static IEnumerable<Entity> GetEntities(string utterance, IDictionary<string, object> entities)
+        private static IEnumerable<IEntity> GetEntities(string utterance, IDictionary<string, object> entities)
         {
             if (entities == null || entities.Count == 0)
             {
                 return null;
             }
 
-            IEnumerable<Entity> getEntitiesForType(string type, object instances, JToken metadata)
+            IEnumerable<IEntity> getEntitiesForType(string type, object instances, JToken metadata)
             {
                 if (instances is JArray instancesJson)
                 {
@@ -115,10 +115,10 @@ namespace NLU.DevOps.Luis
                         .SelectMany(e => e);
                 }
 
-                return Array.Empty<Entity>();
+                return Array.Empty<IEntity>();
             }
 
-            IEnumerable<Entity> getEntitiesRecursive(string entityType, JToken entityJson, JToken entityMetadata)
+            IEnumerable<IEntity> getEntitiesRecursive(string entityType, JToken entityJson, JToken entityMetadata)
             {
                 var startIndex = entityMetadata.Value<int>("startIndex");
                 var length = entityMetadata.Value<int>("length");
@@ -192,7 +192,7 @@ namespace NLU.DevOps.Luis
             return json;
         }
 
-        private LabeledUtterance LuisResultToLabeledUtterance(SpeechPredictionResponse speechPredictionResponse)
+        private ILabeledUtterance LuisResultToLabeledUtterance(SpeechPredictionResponse speechPredictionResponse)
         {
             if (speechPredictionResponse == null)
             {

--- a/src/NLU.DevOps.MockProvider/MockNLUClient.cs
+++ b/src/NLU.DevOps.MockProvider/MockNLUClient.cs
@@ -16,7 +16,7 @@ namespace NLU.DevOps.MockProvider
     {
         public MockNLUClient(string trainedUtterances)
         {
-            this.Utterances = new List<LabeledUtterance>();
+            this.Utterances = new List<ILabeledUtterance>();
             if (trainedUtterances != null)
             {
                 this.Utterances.AddRange(
@@ -26,9 +26,9 @@ namespace NLU.DevOps.MockProvider
 
         public string TrainedUtterances => JsonConvert.SerializeObject(this.Utterances);
 
-        private List<LabeledUtterance> Utterances { get; }
+        private List<ILabeledUtterance> Utterances { get; }
 
-        public Task TrainAsync(IEnumerable<LabeledUtterance> utterances, CancellationToken cancellationToken)
+        public Task TrainAsync(IEnumerable<ILabeledUtterance> utterances, CancellationToken cancellationToken)
         {
             this.Utterances.AddRange(utterances);
             return Task.CompletedTask;
@@ -39,15 +39,15 @@ namespace NLU.DevOps.MockProvider
             return Task.CompletedTask;
         }
 
-        protected override Task<LabeledUtterance> TestAsync(string utterance, CancellationToken cancellationToken)
+        protected override Task<ILabeledUtterance> TestAsync(string utterance, CancellationToken cancellationToken)
         {
             var matchedUtterance = this.Utterances.FirstOrDefault(u => u.Text == utterance) ?? new LabeledUtterance(null, null, null);
             return Task.FromResult(matchedUtterance.WithTimestamp(DateTimeOffset.Now));
         }
 
-        protected override Task<LabeledUtterance> TestSpeechAsync(string speechFile, CancellationToken cancellationToken)
+        protected override Task<ILabeledUtterance> TestSpeechAsync(string speechFile, CancellationToken cancellationToken)
         {
-            return Task.FromResult(new LabeledUtterance(null, null, null));
+            return Task.FromResult<ILabeledUtterance>(new LabeledUtterance(null, null, null));
         }
 
         protected override void Dispose(bool disposing)

--- a/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
+++ b/src/NLU.DevOps.ModelPerformance.Tests/TestCaseSourceTests.cs
@@ -790,7 +790,7 @@ namespace NLU.DevOps.ModelPerformance.Tests
             return json != null ? JToken.Parse(json) : null;
         }
 
-        private static TestCaseSource.LabeledUtteranceTestInput CreatePair(params LabeledUtterance[] pair)
+        private static TestCaseSource.LabeledUtteranceTestInput CreatePair(params ILabeledUtterance[] pair)
         {
             return new TestCaseSource.LabeledUtteranceTestInput(string.Empty, pair[0], pair[1], GetDefaultTestSettings());
         }

--- a/src/NLU.DevOps.ModelPerformance/LabeledUtteranceExtensions.cs
+++ b/src/NLU.DevOps.ModelPerformance/LabeledUtteranceExtensions.cs
@@ -15,17 +15,17 @@ namespace NLU.DevOps.ModelPerformance
         private const string StrictEntitiesPropertyName = "strictEntities";
         private const string UtteranceIdPropertyName = "utteranceId";
 
-        public static IReadOnlyList<string> GetIgnoreEntities(this LabeledUtterance utterance)
+        public static IReadOnlyList<string> GetIgnoreEntities(this ILabeledUtterance utterance)
         {
             return utterance.GetProperty<JArray>(IgnoreEntitiesPropertyName)?.ToObject<string[]>() ?? Array.Empty<string>();
         }
 
-        public static IReadOnlyList<string> GetStrictEntities(this LabeledUtterance utterance)
+        public static IReadOnlyList<string> GetStrictEntities(this ILabeledUtterance utterance)
         {
             return utterance.GetProperty<JArray>(StrictEntitiesPropertyName)?.ToObject<string[]>() ?? Array.Empty<string>();
         }
 
-        public static string GetUtteranceId(this LabeledUtterance utterance)
+        public static string GetUtteranceId(this ILabeledUtterance utterance)
         {
             return utterance.GetProperty<string>(UtteranceIdPropertyName);
         }

--- a/src/NLU.DevOps.ModelPerformance/TestCase.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestCase.cs
@@ -29,8 +29,8 @@ namespace NLU.DevOps.ModelPerformance
             string utteranceId,
             ConfusionMatrixResultKind resultKind,
             ComparisonTargetKind targetKind,
-            LabeledUtterance expectedUtterance,
-            LabeledUtterance actualUtterance,
+            ILabeledUtterance expectedUtterance,
+            ILabeledUtterance actualUtterance,
             double? score,
             string group,
             string testName,
@@ -77,12 +77,12 @@ namespace NLU.DevOps.ModelPerformance
         /// <summary>
         /// Gets the expected utterance.
         /// </summary>
-        public LabeledUtterance ExpectedUtterance { get; }
+        public ILabeledUtterance ExpectedUtterance { get; }
 
         /// <summary>
         /// Gets the actual utterance.
         /// </summary>
-        public LabeledUtterance ActualUtterance { get; }
+        public ILabeledUtterance ActualUtterance { get; }
 
         /// <summary>
         /// Gets the confidence score.

--- a/src/NLU.DevOps.ModelPerformance/TestCaseSource.cs
+++ b/src/NLU.DevOps.ModelPerformance/TestCaseSource.cs
@@ -48,8 +48,8 @@ namespace NLU.DevOps.ModelPerformance
         /// <param name="actualUtterances">Actual utterances.</param>
         /// <param name="testSettings">Test settings.</param>
         public static NLUCompareResults GetNLUCompareResults(
-            IReadOnlyList<LabeledUtterance> expectedUtterances,
-            IReadOnlyList<LabeledUtterance> actualUtterances,
+            IReadOnlyList<ILabeledUtterance> expectedUtterances,
+            IReadOnlyList<ILabeledUtterance> actualUtterances,
             TestSettings testSettings)
         {
             if (expectedUtterances == null)
@@ -72,7 +72,7 @@ namespace NLU.DevOps.ModelPerformance
                 throw new InvalidOperationException("Expected the same number of utterances in the expected and actual sources.");
             }
 
-            string getUtteranceId(LabeledUtterance utterance, int index)
+            string getUtteranceId(ILabeledUtterance utterance, int index)
             {
                 return utterance.GetUtteranceId() ?? index.ToString(CultureInfo.InvariantCulture);
             }
@@ -260,21 +260,21 @@ namespace NLU.DevOps.ModelPerformance
                 yield break;
             }
 
-            bool isEntityMatch(Entity expectedEntity, Entity actualEntity)
+            bool isEntityMatch(IEntity expectedEntity, IEntity actualEntity)
             {
                 return expectedEntity.EntityType == actualEntity.EntityType
                     && (isEntityTextMatch(expectedEntity, actualEntity)
                     || isEntityValueMatch(expectedEntity, actualEntity));
             }
 
-            bool isEntityTextMatch(Entity expectedEntity, Entity actualEntity)
+            bool isEntityTextMatch(IEntity expectedEntity, IEntity actualEntity)
             {
                 return expectedEntity.MatchText != null
                     && EqualsNormalized(expectedEntity.MatchText, actualEntity.MatchText)
                     && expectedEntity.MatchIndex == actualEntity.MatchIndex;
             }
 
-            bool isEntityValueMatch(Entity expectedEntity, Entity actualEntity)
+            bool isEntityValueMatch(IEntity expectedEntity, IEntity actualEntity)
             {
                 /* Required case to support NLU providers that do not specify matched text */
                 return actualEntity.MatchText == null
@@ -384,7 +384,7 @@ namespace NLU.DevOps.ModelPerformance
 
         private static bool IsStrictEntity(
             string entityType,
-            LabeledUtterance expectedUtterance,
+            ILabeledUtterance expectedUtterance,
             TestSettings testSettings)
         {
             var localIgnoreEntities = expectedUtterance.GetIgnoreEntities();
@@ -561,8 +561,8 @@ namespace NLU.DevOps.ModelPerformance
         private static TestCase TruePositive(
             string utteranceId,
             ComparisonTargetKind targetKind,
-            LabeledUtterance expectedUtterance,
-            LabeledUtterance actualUtterance,
+            ILabeledUtterance expectedUtterance,
+            ILabeledUtterance actualUtterance,
             double? score,
             string group,
             string[] args,
@@ -585,8 +585,8 @@ namespace NLU.DevOps.ModelPerformance
         private static TestCase TrueNegative(
             string utteranceId,
             ComparisonTargetKind targetKind,
-            LabeledUtterance expectedUtterance,
-            LabeledUtterance actualUtterance,
+            ILabeledUtterance expectedUtterance,
+            ILabeledUtterance actualUtterance,
             double? score,
             string group,
             string[] args,
@@ -609,8 +609,8 @@ namespace NLU.DevOps.ModelPerformance
         private static TestCase FalsePositive(
             string utteranceId,
             ComparisonTargetKind targetKind,
-            LabeledUtterance expectedUtterance,
-            LabeledUtterance actualUtterance,
+            ILabeledUtterance expectedUtterance,
+            ILabeledUtterance actualUtterance,
             double? score,
             string group,
             string[] args,
@@ -633,8 +633,8 @@ namespace NLU.DevOps.ModelPerformance
         private static TestCase FalseNegative(
             string utteranceId,
             ComparisonTargetKind targetKind,
-            LabeledUtterance expectedUtterance,
-            LabeledUtterance actualUtterance,
+            ILabeledUtterance expectedUtterance,
+            ILabeledUtterance actualUtterance,
             double? score,
             string group,
             string[] args,
@@ -658,8 +658,8 @@ namespace NLU.DevOps.ModelPerformance
             string utteranceId,
             ConfusionMatrixResultKind resultKind,
             ComparisonTargetKind targetKind,
-            LabeledUtterance expectedUtterance,
-            LabeledUtterance actualUtterance,
+            ILabeledUtterance expectedUtterance,
+            ILabeledUtterance actualUtterance,
             double? score,
             string group,
             string[] args,
@@ -689,8 +689,8 @@ namespace NLU.DevOps.ModelPerformance
         {
             public LabeledUtteranceTestInput(
                 string utteranceId,
-                LabeledUtterance expected,
-                LabeledUtterance actual,
+                ILabeledUtterance expected,
+                ILabeledUtterance actual,
                 TestSettings testSettings)
             {
                 this.UtteranceId = utteranceId;
@@ -701,9 +701,9 @@ namespace NLU.DevOps.ModelPerformance
 
             public string UtteranceId { get; }
 
-            public LabeledUtterance Expected { get; }
+            public ILabeledUtterance Expected { get; }
 
-            public LabeledUtterance Actual { get; }
+            public ILabeledUtterance Actual { get; }
 
             public TestSettings TestSettings { get; }
         }

--- a/src/NLU.DevOps.Models/IEntity.cs
+++ b/src/NLU.DevOps.Models/IEntity.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.Models
+{
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Entity appearing in utterance.
+    /// </summary>
+    public interface IEntity
+    {
+        /// <summary>
+        /// Gets the entity type name.
+        /// </summary>
+        string EntityType { get; }
+
+        /// <summary>
+        /// Gets the entity value, generally a canonical form of the entity.
+        /// </summary>
+        JToken EntityValue { get; }
+
+        /// <summary>
+        /// Gets the matching text in the utterance.
+        /// </summary>
+        string MatchText { get; }
+
+        /// <summary>
+        /// Gets the occurrence index of matching token in the utterance.
+        /// </summary>
+        int MatchIndex { get; }
+    }
+}

--- a/src/NLU.DevOps.Models/ILabeledUtterance.cs
+++ b/src/NLU.DevOps.Models/ILabeledUtterance.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace NLU.DevOps.Models
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Labeled utterance.
+    /// </summary>
+    public interface ILabeledUtterance
+    {
+        /// <summary>
+        /// Gets the text of the utterance.
+        /// </summary>
+        string Text { get; }
+
+        /// <summary>
+        /// Gets the intent of the utterance.
+        /// </summary>
+        string Intent { get; }
+
+        /// <summary>
+        /// Gets the entities referenced in the utterance.
+        /// </summary>
+        IReadOnlyList<IEntity> Entities { get; }
+    }
+}

--- a/src/NLU.DevOps.Models/INLUTestClient.cs
+++ b/src/NLU.DevOps.Models/INLUTestClient.cs
@@ -19,7 +19,7 @@ namespace NLU.DevOps.Models
         /// <returns>Task to await the resulting labeled utterance.</returns>
         /// <param name="query">Query to test.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        Task<LabeledUtterance> TestAsync(
+        Task<ILabeledUtterance> TestAsync(
             JToken query,
             CancellationToken cancellationToken);
 
@@ -30,7 +30,7 @@ namespace NLU.DevOps.Models
         /// <param name="speechFile">Speech file to test on.</param>
         /// <param name="query">Query to test.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        Task<LabeledUtterance> TestSpeechAsync(
+        Task<ILabeledUtterance> TestSpeechAsync(
             string speechFile,
             JToken query,
             CancellationToken cancellationToken);

--- a/src/NLU.DevOps.Models/INLUTrainClient.cs
+++ b/src/NLU.DevOps.Models/INLUTrainClient.cs
@@ -20,7 +20,7 @@ namespace NLU.DevOps.Models
         /// <param name="utterances">Labeled utterances to train on.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         Task TrainAsync(
-            IEnumerable<LabeledUtterance> utterances,
+            IEnumerable<ILabeledUtterance> utterances,
             CancellationToken cancellationToken);
 
         /// <summary>

--- a/src/NLU.DevOps.Models/NLU.DevOps.Models.csproj
+++ b/src/NLU.DevOps.Models/NLU.DevOps.Models.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CodeAnalysis.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>0.7.0</AssemblyVersion>
+    <AssemblyVersion>0.8.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">

--- a/src/NLU.DevOps.Models/NLUClientExtensions.cs
+++ b/src/NLU.DevOps.Models/NLUClientExtensions.cs
@@ -19,7 +19,7 @@ namespace NLU.DevOps.Models
         /// <returns>Task to await the training operation.</returns>
         /// <param name="instance">NLU training client instance.</param>
         /// <param name="utterances">Labeled utterances to train on.</param>
-        public static Task TrainAsync(this INLUTrainClient instance, IEnumerable<LabeledUtterance> utterances)
+        public static Task TrainAsync(this INLUTrainClient instance, IEnumerable<ILabeledUtterance> utterances)
         {
             return instance.TrainAsync(utterances, CancellationToken.None);
         }
@@ -40,7 +40,7 @@ namespace NLU.DevOps.Models
         /// <returns>Task to await the resulting labeled utterance.</returns>
         /// <param name="instance">NLU testing client instance.</param>
         /// <param name="query">Query to test.</param>
-        public static Task<LabeledUtterance> TestAsync(this INLUTestClient instance, JToken query)
+        public static Task<ILabeledUtterance> TestAsync(this INLUTestClient instance, JToken query)
         {
             return instance.TestAsync(query, CancellationToken.None);
         }
@@ -51,7 +51,7 @@ namespace NLU.DevOps.Models
         /// <returns>Task to await the resulting labeled utterance.</returns>
         /// <param name="instance">NLU testing client instance.</param>
         /// <param name="speechFile">Speech file.</param>
-        public static Task<LabeledUtterance> TestSpeechAsync(this INLUTestClient instance, string speechFile)
+        public static Task<ILabeledUtterance> TestSpeechAsync(this INLUTestClient instance, string speechFile)
         {
             return instance.TestSpeechAsync(speechFile, null);
         }
@@ -63,7 +63,7 @@ namespace NLU.DevOps.Models
         /// <param name="instance">NLU testing client instance.</param>
         /// <param name="speechFile">Speech file.</param>
         /// <param name="query">Query to test.</param>
-        public static Task<LabeledUtterance> TestSpeechAsync(this INLUTestClient instance, string speechFile, JToken query)
+        public static Task<ILabeledUtterance> TestSpeechAsync(this INLUTestClient instance, string speechFile, JToken query)
         {
             return instance.TestSpeechAsync(speechFile, query, CancellationToken.None);
         }


### PR DESCRIPTION
The LabeledUtterance and Entity base types never needed to be concrete classes. There is another issue (#320) that we cannot solve until we can carry the entire utterance JSON through to the compare logic, which likely requires an interface.

This change swaps the concrete base types for interfaces.

Fixes #321