### PR TITLE
Fixes issue with where NLU results are downloaded

### DIFF
--- a/.azdo/templates/jobs/nlu/cli.yml
+++ b/.azdo/templates/jobs/nlu/cli.yml
@@ -72,7 +72,7 @@ jobs:
         --expected models/tests.json
         --actual $(Build.ArtifactStagingDirectory)/results.json
         --test-settings models/compare.yml
-        --baseline $(Pipeline.Workspace)/nlu/statistics.json
+        --baseline $(Pipeline.Workspace)/statistics.json
         --output-folder $(Build.ArtifactStagingDirectory)
 
   - task: DotNetCoreCLI@2


### PR DESCRIPTION
When using `DownloadPipelineArtifact` as opposed to `download`, the artifacts are flattened into $(Pipeline.Workspace) (rather than being placed into a sub-folder named after the artifact). This updates the baseline path to point to the correct location for downloaded NLU results.